### PR TITLE
[codex] add artist smols endpoint

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -43,3 +43,6 @@ CREATE TABLE IF NOT EXISTS Mixtapes (
     "Address" TEXT NOT NULL,
     Created_At DATETIME DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE INDEX IF NOT EXISTS idx_smols_artist_public_created
+ON Smols("Address", Public, Created_At DESC, Id DESC);

--- a/src/api/artists.ts
+++ b/src/api/artists.ts
@@ -1,0 +1,92 @@
+import { Hono } from 'hono'
+import { cache } from 'hono/cache'
+import type { HonoEnv } from '../types'
+import {
+	parsePaginationParams,
+	buildCursorWhereClause,
+	buildPaginationResponse,
+} from '../utils/pagination'
+import { artistSmolsCacheTag } from '../utils/cache-tags'
+
+const artists = new Hono<HonoEnv>()
+
+interface Artist {
+	Username: string
+	Address: string
+}
+
+interface ArtistSmol {
+	Id: string
+	Title: string
+	Song_1: string
+	Address: string
+	Plays: number
+	Views: number
+	Mint_Token: string | null
+	Mint_Amm: string | null
+	Created_At: string
+}
+
+artists.get(
+	'/:address/smols',
+	cache({
+		cacheName: 'smol-workflow',
+		cacheControl: 'public, max-age=30, stale-while-revalidate=60',
+	}),
+	async (c) => {
+		const { env, req } = c
+		const artistAddress = c.req.param('address')
+		const { limit, cursor } = parsePaginationParams(new URL(req.url))
+
+		const whereClause = buildCursorWhereClause(cursor, 's."Address" = ? AND s.Public = 1', 's.')
+		const bindings: any[] = []
+
+		const query = `
+			SELECT s.Id, s.Title, s.Song_1, s.Address, s.Plays, s.Views, s.Mint_Token, s.Mint_Amm, s.Created_At
+			FROM Smols s
+			WHERE ${whereClause[0]}
+			ORDER BY s.Created_At DESC, s.Id DESC
+			LIMIT ?
+		`
+
+		if (whereClause.length > 1) {
+			bindings.push(artistAddress, whereClause[1], whereClause[2], whereClause[3], limit)
+		} else {
+			bindings.push(artistAddress, limit)
+		}
+
+		const smolsD1Result = await env.SMOL_D1.prepare(query)
+			.bind(...bindings)
+			.all<ArtistSmol>()
+
+		const smolsFromDb = smolsD1Result.results || []
+		let artist: Artist | null = null
+		if (smolsFromDb.length > 0) {
+			artist = await env.SMOL_D1.prepare(
+				`SELECT Username, Address FROM Users WHERE Address = ? LIMIT 1`
+			)
+				.bind(artistAddress)
+				.first<Artist>()
+		}
+
+		const pagination = buildPaginationResponse(
+			smolsFromDb,
+			limit,
+			(item) => item.Created_At,
+			(item) => item.Id
+		)
+
+		const response = c.json({
+			artist: artist ?? null,
+			smols: smolsFromDb,
+			users: artist ? [artist] : [],
+			pagination,
+		})
+
+		response.headers.append('Cache-Tag', artistSmolsCacheTag(artistAddress))
+
+		return response
+	}
+)
+
+export default artists

--- a/src/api/smols.ts
+++ b/src/api/smols.ts
@@ -9,9 +9,12 @@ import {
 	buildPaginationResponse,
 } from '../utils/pagination'
 import {
+	purgeArtistSmolsCache,
 	purgeCacheByTags,
+	purgePublicSmolsCache,
 	userCacheKeyGenerator,
 } from '../utils/cache'
+import { artistSmolsCacheTag } from '../utils/cache-tags'
 import { isDurableObjectId } from '../utils/durable-object-id'
 import { queueSearchDeletionById } from '../utils/search'
 import { requireOwnedVisibilityToggle, syncSearchVisibilityAfterToggle } from '../utils/search-visibility'
@@ -409,7 +412,11 @@ smols.put('/:id', parseAuth, async (c) => {
 
 	// Purge user's individual page
 	c.executionCtx.waitUntil(
-		purgeCacheByTags([`user:${payload.sub}:smol:${id}`])
+		Promise.all([
+			purgeArtistSmolsCache(payload.sub),
+			purgePublicSmolsCache(),
+			purgeCacheByTags([`user:${payload.sub}:smol:${id}`]),
+		])
 	)
 
 	return c.body(null, 204)
@@ -517,6 +524,8 @@ smols.delete('/admin/bulk', parseAuth, async (c) => {
 		// Purge caches for this smol's owner
 		c.executionCtx.waitUntil(
 			purgeCacheByTags([
+				artistSmolsCacheTag(smol.Address),
+				'public-smols',
 				`user:${smol.Address}:created`,
 				`user:${smol.Address}:smol:${id}`,
 				`smol:${id}:anonymous`,
@@ -580,6 +589,8 @@ smols.delete('/:id', parseAuth, async (c) => {
 	// Purge user's created list and individual page
 	c.executionCtx.waitUntil(
 		purgeCacheByTags([
+			artistSmolsCacheTag(payload.sub),
+			'public-smols',
 			`user:${payload.sub}:created`,
 			`user:${payload.sub}:smol:${id}`,
 		])

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import mixtapes from './api/mixtapes'
 import mint from './api/mint'
 import media from './api/media'
 import search from './api/search'
+import artists from './api/artists'
 import { processSearchQueue, processSearchDLQ, runSearchBackfillCron } from './utils/search'
 
 export const app = new Hono<HonoEnv>()
@@ -42,6 +43,7 @@ app.route('/mint', mint)
 app.route('/song', media)
 app.route('/image', media)
 app.route('/search', search)
+app.route('/artists', artists)
 app.route('/', smols)
 
 // 404 handler

--- a/src/tx-workflow.ts
+++ b/src/tx-workflow.ts
@@ -4,6 +4,7 @@ import { basicNodeSigner } from "@stellar/stellar-sdk/minimal/contract";
 import { env, WorkflowEntrypoint, WorkflowEvent, WorkflowStep, WorkflowStepConfig } from "cloudflare:workers";
 import { Client as SmolClient } from "smol-sdk";
 import { purgeCacheByTags } from "./utils/cache";
+import { artistSmolsCacheTag } from "./utils/cache-tags";
 
 type KaleWorkerBinding = Fetcher & {
 	submitTransaction(input: { xdr: string }): Promise<{
@@ -96,24 +97,40 @@ export class TxWorkflow extends WorkflowEntrypoint<Env, WorkflowTxParams> {
             // as contract addresses are deterministic and we could get the values from the simulation
             await step.do('persist mint metadata', config, async () => {
                 const [tokenSACAddress, cometAMMAddress] = scValToNative(xdr.ScVal.fromXDR(res.returnValue, 'base64'));
+                const id = event.payload.entropy!;
 
                 await this.env.SMOL_D1.prepare(`
                     UPDATE Smols
                     SET Mint_Token = ?1, Mint_Amm = ?2
                     WHERE Id = ?3
                 `)
-                    .bind(tokenSACAddress, cometAMMAddress, event.payload.entropy)
+                    .bind(tokenSACAddress, cometAMMAddress, id)
                     .run();
 
-                // Purge user's individual smol page
-                await purgeCacheByTags([`user:${event.payload.sub}:smol:${event.payload.entropy}`]);
+                const smol = await this.env.SMOL_D1.prepare(`
+                    SELECT Address
+                    FROM Smols
+                    WHERE Id = ?1
+                `)
+                    .bind(id)
+                    .first<{ Address: string | null }>();
+
+                const tags = [
+                    `user:${event.payload.sub}:smol:${id}`,
+                    `smol:${id}:anonymous`,
+                    'public-smols',
+                ];
+                if (smol?.Address) {
+                    tags.push(artistSmolsCacheTag(smol.Address));
+                }
+
+                await purgeCacheByTags(tags);
             });
         } else if (event.payload.type === 'batch-mint') {
             await step.do('persist batch mint metadata', config, async () => {
                 const results = scValToNative(xdr.ScVal.fromXDR(res.returnValue, 'base64')) as [string, string][];
 
-                // Collect smol IDs for cache purging
-                const smolCacheTags: string[] = [];
+                const cacheTags = new Set<string>(['public-smols']);
 
                 for (let i = 0; i < results.length; i++) {
                     const [tokenSACAddress, cometAMMAddress] = results[i];
@@ -127,13 +144,23 @@ export class TxWorkflow extends WorkflowEntrypoint<Env, WorkflowTxParams> {
                         .bind(tokenSACAddress, cometAMMAddress, id)
                         .run();
 
-                    // Collect cache tags for user's individual smol pages
-                    smolCacheTags.push(`user:${event.payload.sub}:smol:${id}`);
+                    const smol = await this.env.SMOL_D1.prepare(`
+                        SELECT Address
+                        FROM Smols
+                        WHERE Id = ?1
+                    `)
+                        .bind(id)
+                        .first<{ Address: string | null }>();
+
+                    cacheTags.add(`user:${event.payload.sub}:smol:${id}`);
+                    cacheTags.add(`smol:${id}:anonymous`);
+                    if (smol?.Address) {
+                        cacheTags.add(artistSmolsCacheTag(smol.Address));
+                    }
                 }
 
-                // Purge user's individual smol pages
-                if (smolCacheTags.length > 0) {
-                    await purgeCacheByTags(smolCacheTags);
+                if (cacheTags.size > 0) {
+                    await purgeCacheByTags([...cacheTags]);
                 }
             });
         }

--- a/src/utils/cache-tags.ts
+++ b/src/utils/cache-tags.ts
@@ -1,0 +1,3 @@
+export function artistSmolsCacheTag(artistAddress: string): string {
+	return `artist:${encodeURIComponent(artistAddress)}:smols`
+}

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -5,6 +5,7 @@
 import { env } from 'cloudflare:workers'
 import type { Context } from 'hono'
 import type { HonoEnv } from '../types'
+import { artistSmolsCacheTag } from './cache-tags'
 
 /**
  * Purge cache by tags using Cloudflare API
@@ -92,6 +93,13 @@ export function purgeMixtapesCache(): Promise<boolean> {
  */
 export function purgePublicSmolsCache(): Promise<boolean> {
 	return purgeCacheByTags(['public-smols'])
+}
+
+/**
+ * Helper to purge public smols for a specific artist.
+ */
+export function purgeArtistSmolsCache(artistAddress: string): Promise<boolean> {
+	return purgeCacheByTags([artistSmolsCacheTag(artistAddress)])
 }
 
 /**

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -4,7 +4,7 @@ import { imageDescribe } from './ai/cf';
 import { generateLyrics } from './ai/aisonggenerator';
 import { checkNSFW } from './ai/nsfw';
 import { NonRetryableError } from 'cloudflare:workflows';
-import { purgePlaylistCache, purgeUserCreatedCache, purgePublicSmolsCache } from './utils/cache';
+import { purgeArtistSmolsCache, purgePlaylistCache, purgeUserCreatedCache, purgePublicSmolsCache } from './utils/cache';
 import { decideSongsStrategy, pollUntilComplete } from './utils/songs';
 import { isDurableObjectId } from './utils/durable-object-id';
 import { createHiddenSearchState, createQueuedSearchState, queueSearchDeletionById, queueSearchIndexingById } from './utils/search';
@@ -296,6 +296,7 @@ export class Workflow extends WorkflowEntrypoint<Env, WorkflowParams> {
 
 			// Purge caches so the smol appears immediately
 			await Promise.all([
+				purgeArtistSmolsCache(address),
 				purgeUserCreatedCache(address),
 				purgePublicSmolsCache(),
 			]);

--- a/test/artists.test.ts
+++ b/test/artists.test.ts
@@ -1,0 +1,146 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import artists from '../src/api/artists'
+import { encodeCursor } from '../src/utils/pagination'
+
+type PreparedCall = {
+	sql: string
+	bindings: unknown[]
+}
+
+type MockSmol = {
+	Id: string
+	Title: string
+	Song_1: string
+	Address: string
+	Plays: number
+	Views: number
+	Mint_Token: string | null
+	Mint_Amm: string | null
+	Created_At: string
+}
+
+function installCacheMock() {
+	Reflect.set(globalThis, 'caches', {
+		open: async () => ({
+			match: async () => undefined,
+			put: async () => undefined,
+		}),
+	})
+}
+
+function createEnv(options: {
+	smols?: MockSmol[]
+	artist?: { Username: string; Address: string } | null
+}) {
+	const calls: PreparedCall[] = []
+
+	const env = {
+		SMOL_D1: {
+			prepare(sql: string) {
+				return {
+					bind(...bindings: unknown[]) {
+						calls.push({ sql, bindings })
+
+						return {
+							all: async <T>() => {
+								assert.match(sql, /s\."Address" = \? AND s\.Public = 1/)
+								assert.match(sql, /ORDER BY s\.Created_At DESC, s\.Id DESC/)
+								return { results: (options.smols ?? []) as T[] }
+							},
+							first: async <T>() => {
+								assert.match(sql, /SELECT Username, Address FROM Users/)
+								return (options.artist ?? null) as T | null
+							},
+							run: async () => ({ success: true }),
+						}
+					},
+				}
+			},
+		},
+	} as unknown as Env
+
+	return { env, calls }
+}
+
+test('artist smols endpoint lists only public smols for one artist query', async () => {
+	installCacheMock()
+	const artistAddress = 'CARTIST'
+	const smol = {
+		Id: 'smol-2',
+		Title: 'Public song',
+		Song_1: 'song-1',
+		Address: artistAddress,
+		Plays: 4,
+		Views: 8,
+		Mint_Token: null,
+		Mint_Amm: null,
+		Created_At: '2026-05-14T12:00:00.000Z',
+	}
+	const { env, calls } = createEnv({
+		smols: [smol],
+		artist: { Username: 'Artist', Address: artistAddress },
+	})
+
+	const response = await artists.request(`/${artistAddress}/smols?limit=1`, {}, env)
+	const body = await response.json() as {
+		artist: { Username: string; Address: string } | null
+		smols: MockSmol[]
+		users: Array<{ Username: string; Address: string }>
+		pagination: { nextCursor: string | null; hasMore: boolean }
+	}
+
+	assert.equal(response.status, 200)
+	assert.deepEqual(body.artist, { Username: 'Artist', Address: artistAddress })
+	assert.deepEqual(body.users, [{ Username: 'Artist', Address: artistAddress }])
+	assert.deepEqual(body.smols, [smol])
+	assert.equal(body.pagination.hasMore, true)
+	assert.equal(body.pagination.nextCursor, encodeCursor(smol.Created_At, smol.Id))
+	assert.deepEqual(calls[0].bindings, [artistAddress, 1])
+	assert.deepEqual(calls[1].bindings, [artistAddress])
+	assert.equal(response.headers.get('Cache-Tag'), `artist:${artistAddress}:smols`)
+})
+
+test('artist smols endpoint includes cursor bindings after artist address', async () => {
+	installCacheMock()
+	const cursor = encodeCursor('2026-05-14T12:00:00.000Z', 'smol-2')
+	const { env, calls } = createEnv({
+		smols: [],
+		artist: null,
+	})
+
+	const response = await artists.request(`/CARTIST/smols?limit=25&cursor=${encodeURIComponent(cursor)}`, {}, env)
+	const body = await response.json() as {
+		artist: null
+		smols: MockSmol[]
+		users: Array<{ Username: string; Address: string }>
+		pagination: { nextCursor: string | null; hasMore: boolean }
+	}
+
+	assert.equal(response.status, 200)
+	assert.equal(body.artist, null)
+	assert.deepEqual(body.users, [])
+	assert.deepEqual(body.smols, [])
+	assert.deepEqual(body.pagination, { nextCursor: null, hasMore: false })
+	assert.match(calls[0].sql, /s\.Created_At < \? OR \(s\.Created_At = \? AND s\.Id < \?\)/)
+	assert.deepEqual(calls[0].bindings, [
+		'CARTIST',
+		'2026-05-14T12:00:00.000Z',
+		'2026-05-14T12:00:00.000Z',
+		'smol-2',
+		25,
+	])
+})
+
+test('artist smols endpoint encodes artist cache tag values', async () => {
+	installCacheMock()
+	const { env } = createEnv({
+		smols: [],
+		artist: null,
+	})
+
+	const response = await artists.request('/artist%3Aone/smols', {}, env)
+
+	assert.equal(response.status, 200)
+	assert.equal(response.headers.get('Cache-Tag'), 'artist:artist%3Aone:smols')
+})


### PR DESCRIPTION
## Summary
- Add GET /artists/:address/smols with cursor pagination over public artist smols
- Add encoded artist cache tags and purge artist/public caches on create/delete/toggle/mint updates
- Add a D1 index for artist/public/created ordering and route tests for query guards, cursor binding, and cache tags

## Review notes
- Solo Claude and Codex adversarial reviewers checked the plan/patch.
- Incorporated feedback for mint cache invalidation, query indexing, avoiding user-profile lookup on empty public results, and cache-tag hardening.

## Validation
- npm run typecheck
- npm test