### PR TITLE
[codex] Harden public smol endpoints

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -50,6 +50,12 @@ ON Smols(Public, Created_At DESC, Id DESC);
 CREATE INDEX IF NOT EXISTS idx_smols_address_created
 ON Smols("Address", Created_At DESC, Id DESC);
 
+CREATE INDEX IF NOT EXISTS idx_smols_song_1
+ON Smols(Song_1);
+
+CREATE INDEX IF NOT EXISTS idx_smols_song_2
+ON Smols(Song_2);
+
 CREATE INDEX IF NOT EXISTS idx_likes_address_id
 ON Likes("Address", Id);
 

--- a/schema.sql
+++ b/schema.sql
@@ -58,3 +58,6 @@ ON Playlists(Title, Id);
 
 CREATE INDEX IF NOT EXISTS idx_mixtapes_created
 ON Mixtapes(Created_At DESC, Id DESC);
+
+CREATE INDEX IF NOT EXISTS idx_users_address
+ON Users("Address");

--- a/schema.sql
+++ b/schema.sql
@@ -43,3 +43,18 @@ CREATE TABLE IF NOT EXISTS Mixtapes (
     "Address" TEXT NOT NULL,
     Created_At DATETIME DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE INDEX IF NOT EXISTS idx_smols_public_created
+ON Smols(Public, Created_At DESC, Id DESC);
+
+CREATE INDEX IF NOT EXISTS idx_smols_address_created
+ON Smols("Address", Created_At DESC, Id DESC);
+
+CREATE INDEX IF NOT EXISTS idx_likes_address_id
+ON Likes("Address", Id);
+
+CREATE INDEX IF NOT EXISTS idx_playlists_title_id
+ON Playlists(Title, Id);
+
+CREATE INDEX IF NOT EXISTS idx_mixtapes_created
+ON Mixtapes(Created_At DESC, Id DESC);

--- a/src/ai/pixellab.ts
+++ b/src/ai/pixellab.ts
@@ -1,12 +1,14 @@
-const PIXELLAB_KEY = '8e3623e3-43e1-4699-a031-eb7fa7753f6a'
-
 // TODO very probably need to run some sort of sentiment analysis on this to filter out NSFW stuff
 
-export async function pixellab(description: string, model: 'pixflux' | 'bitforge') {
+export async function pixellab(env: Env, description: string, model: 'pixflux' | 'bitforge') {
     let res: any
 
     if (!model || !description)
         throw new Error('Missing parameters')
+
+    if (!env.PIXELLAB_KEY) {
+        throw new Error('Missing Pixellab API key')
+    }
 
     // description = `
     //     A rich scene without any characters or people.
@@ -15,10 +17,10 @@ export async function pixellab(description: string, model: 'pixflux' | 'bitforge
 
     switch (model) {
         case 'pixflux':
-            res = await pixflux(description)
+            res = await pixflux(env, description)
             break
         case 'bitforge':
-            res = await bitforge(description)
+            res = await bitforge(env, description)
             break
         default:
             throw new Error('Model not found')
@@ -27,7 +29,7 @@ export async function pixellab(description: string, model: 'pixflux' | 'bitforge
     return res.image.base64 as string
 }
 
-async function pixflux(description: string) {
+async function pixflux(env: Env, description: string) {
     const width = 64
     // const width = 32
 
@@ -35,7 +37,7 @@ async function pixflux(description: string) {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
-            'Authorization': `Bearer ${PIXELLAB_KEY}`
+            'Authorization': `Bearer ${env.PIXELLAB_KEY}`
         },
         body: JSON.stringify({
             description,
@@ -61,14 +63,14 @@ async function pixflux(description: string) {
         })
 }
 
-async function bitforge(description: string) {
+async function bitforge(env: Env, description: string) {
     const width = 16
 
     return fetch('https://api.pixellab.ai/v1/generate-image-bitforge', {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
-            'Authorization': `Bearer ${PIXELLAB_KEY}`
+            'Authorization': `Bearer ${env.PIXELLAB_KEY}`
         },
         body: JSON.stringify({
             description,

--- a/src/api/likes.ts
+++ b/src/api/likes.ts
@@ -20,8 +20,10 @@ likes.get(
 		const payload = c.get('jwtPayload')!
 
 		const { results } = await env.SMOL_D1.prepare(`
-			SELECT Id FROM Likes
-			WHERE "Address" = ?1
+			SELECT l.Id
+			FROM Likes l
+			INNER JOIN Smols s ON s.Id = l.Id
+			WHERE l."Address" = ?1 AND s.Public = 1
 		`)
 			.bind(payload.sub)
 			.all()
@@ -43,6 +45,19 @@ likes.put('/:id', parseAuth, async (c) => {
 	const id = req.param('id')
 	const payload = c.get('jwtPayload')!
 
+	const deleteResult = await env.SMOL_D1.prepare(
+		`DELETE FROM Likes WHERE Id = ?1 AND "Address" = ?2`
+	)
+		.bind(id, payload.sub)
+		.run()
+
+	if (deleteResult.meta.changes > 0) {
+		c.executionCtx.waitUntil(
+			purgeUserLikedCache(payload.sub, id)
+		)
+		return c.body(null, 204)
+	}
+
 	const smol = await env.SMOL_D1.prepare(
 		`SELECT 1 FROM Smols WHERE Id = ?1 AND Public = 1`
 	)
@@ -53,17 +68,9 @@ likes.put('/:id', parseAuth, async (c) => {
 		return c.body(null, 404)
 	}
 
-	const deleteResult = await env.SMOL_D1.prepare(
-		`DELETE FROM Likes WHERE Id = ?1 AND "Address" = ?2`
-	)
+	await env.SMOL_D1.prepare(`INSERT INTO Likes (Id, "Address") VALUES (?1, ?2)`)
 		.bind(id, payload.sub)
 		.run()
-
-	if (deleteResult.meta.changes === 0) {
-		await env.SMOL_D1.prepare(`INSERT INTO Likes (Id, "Address") VALUES (?1, ?2)`)
-			.bind(id, payload.sub)
-			.run()
-	}
 
 	// Purge cache for this user's liked and likes lists, plus the individual smol detail page
 	// This ensures the liked button updates immediately on the smol detail page

--- a/src/api/likes.ts
+++ b/src/api/likes.ts
@@ -43,6 +43,16 @@ likes.put('/:id', parseAuth, async (c) => {
 	const id = req.param('id')
 	const payload = c.get('jwtPayload')!
 
+	const smol = await env.SMOL_D1.prepare(
+		`SELECT 1 FROM Smols WHERE Id = ?1 AND Public = 1`
+	)
+		.bind(id)
+		.first()
+
+	if (!smol) {
+		return c.body(null, 404)
+	}
+
 	const deleteResult = await env.SMOL_D1.prepare(
 		`DELETE FROM Likes WHERE Id = ?1 AND "Address" = ?2`
 	)

--- a/src/api/likes.ts
+++ b/src/api/likes.ts
@@ -24,7 +24,7 @@ likes.get(
 			SELECT l.Id
 			FROM Likes l
 			INNER JOIN Smols s ON s.Id = l.Id
-			WHERE l."Address" = ?1 AND s.Public = 1
+			WHERE l."Address" = ?1
 		`)
 			.bind(payload.sub)
 			.all()
@@ -60,13 +60,13 @@ likes.put('/:id', parseAuth, async (c) => {
 	}
 
 	const smol = await env.SMOL_D1.prepare(
-		`SELECT 1 FROM Smols WHERE Id = ?1 AND Public = 1`
+		`SELECT 1 FROM Smols WHERE Id = ?1`
 	)
 		.bind(id)
 		.first()
 
 	if (!smol) {
-		throw new HTTPException(404, { message: 'Smol not found or not public' })
+		throw new HTTPException(404, { message: 'Smol not found' })
 	}
 
 	await env.SMOL_D1.prepare(`INSERT OR IGNORE INTO Likes (Id, "Address") VALUES (?1, ?2)`)

--- a/src/api/likes.ts
+++ b/src/api/likes.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import { cache } from 'hono/cache'
+import { HTTPException } from 'hono/http-exception'
 import type { HonoEnv } from '../types'
 import { parseAuth } from '../middleware/auth'
 import { purgeUserLikedCache, userCacheKeyGenerator } from '../utils/cache'
@@ -12,7 +13,7 @@ likes.get(
 	parseAuth,
 	cache({
 		cacheName: 'smol-workflow',
-		cacheControl: 'public, max-age=20, stale-while-revalidate=40',
+		cacheControl: 'private, max-age=20',
 		keyGenerator: userCacheKeyGenerator, // Each user gets separate cache via sub claim
 	}),
 	async (c) => {
@@ -65,10 +66,10 @@ likes.put('/:id', parseAuth, async (c) => {
 		.first()
 
 	if (!smol) {
-		return c.body(null, 404)
+		throw new HTTPException(404, { message: 'Smol not found or not public' })
 	}
 
-	await env.SMOL_D1.prepare(`INSERT INTO Likes (Id, "Address") VALUES (?1, ?2)`)
+	await env.SMOL_D1.prepare(`INSERT OR IGNORE INTO Likes (Id, "Address") VALUES (?1, ?2)`)
 		.bind(id, payload.sub)
 		.run()
 

--- a/src/api/media.ts
+++ b/src/api/media.ts
@@ -1,17 +1,54 @@
-import { Hono } from 'hono'
+import { Context, Hono } from 'hono'
 import { HTTPException } from 'hono/http-exception'
-import { cache } from 'hono/cache'
 import { Jimp, ResizeStrategy } from 'jimp'
 import type { HonoEnv } from '../types'
+import { optionalAuth } from '../middleware/auth'
 import { parseRange } from '../utils'
 
 const media = new Hono<HonoEnv>()
 
+async function getReadableSongRow(c: Context<HonoEnv>, musicId: string) {
+	const payload = c.get('jwtPayload')
+	const row = await c.env.SMOL_D1.prepare(`
+		SELECT Public, "Address" as Address
+		FROM Smols
+		WHERE Song_1 = ?1 OR Song_2 = ?1
+	`)
+		.bind(musicId)
+		.first<{ Public: number; Address: string | null }>()
+
+	if (!row || (row.Public !== 1 && row.Address !== payload?.sub)) {
+		throw new HTTPException(404, { message: 'Song not found' })
+	}
+
+	return row
+}
+
+async function getReadableImageRow(c: Context<HonoEnv>, smolId: string) {
+	const payload = c.get('jwtPayload')
+	const row = await c.env.SMOL_D1.prepare(`
+		SELECT Public, "Address" as Address
+		FROM Smols
+		WHERE Id = ?1
+	`)
+		.bind(smolId)
+		.first<{ Public: number; Address: string | null }>()
+
+	if (!row || (row.Public !== 1 && row.Address !== payload?.sub)) {
+		throw new HTTPException(404, { message: 'Image not found' })
+	}
+
+	return row
+}
+
 // Serve songs
-media.get('/:id{.+\\.mp3}', async (c) => {
+media.get('/:id{.+\\.mp3}', optionalAuth, async (c) => {
 	const { env, req, executionCtx } = c
 	const id = req.param('id')
+	const musicId = id.replace(/\.mp3$/, '')
 	const rangeHeader = req.header('range')
+
+	const smol = await getReadableSongRow(c, musicId)
 
 	const objectMeta = await env.SMOL_BUCKET.head(id)
 
@@ -23,6 +60,10 @@ media.get('/:id{.+\\.mp3}', async (c) => {
 	objectMeta.writeHttpMetadata(headers)
 	headers.set('Accept-Ranges', 'bytes')
 	headers.set('Content-Type', 'audio/mpeg')
+	headers.set(
+		'Cache-Control',
+		smol.Public === 1 ? 'public, max-age=31536000, immutable' : 'no-store'
+	)
 
 	let status = 200
 	let body: ReadableStream | null = null
@@ -57,10 +98,9 @@ media.get('/:id{.+\\.mp3}', async (c) => {
 	const shouldIncrementPlays = !rangeHeader || (rangeHeader && rangeHeader.startsWith('bytes=0-'))
 
 	if (shouldIncrementPlays) {
-		const dbId = id.replace('.mp3', '')
 		executionCtx.waitUntil(
 			env.SMOL_D1.prepare('UPDATE Smols SET Plays = Plays + 1 WHERE Song_1 = ?1 OR Song_2 = ?1')
-				.bind(dbId)
+				.bind(musicId)
 				.run()
 		)
 	}
@@ -74,14 +114,15 @@ media.get('/:id{.+\\.mp3}', async (c) => {
 // Serve images
 media.get(
 	'/:id{.+\\.png}',
-	cache({
-		cacheName: 'smol-workflow',
-		cacheControl: 'public, max-age=31536000, immutable',
-	}),
+	optionalAuth,
 	async (c) => {
 		const { env, req } = c
 		const id = req.param('id')
+		const smolId = id.replace(/\.png$/, '')
 		const scale = req.query('scale')
+
+		const smol = await getReadableImageRow(c, smolId)
+
 		const image = await env.SMOL_BUCKET.get(id)
 
 		if (!image) {
@@ -112,6 +153,9 @@ media.get(
 		return new Response(scaled_image ?? image.body, {
 			headers: {
 				'Content-Type': 'image/png',
+				'Cache-Control': smol.Public === 1
+					? 'public, max-age=31536000, immutable'
+					: 'no-store',
 			},
 		})
 	}

--- a/src/api/media.ts
+++ b/src/api/media.ts
@@ -10,12 +10,12 @@ const media = new Hono<HonoEnv>()
 async function getReadableSongRow(c: Context<HonoEnv>, musicId: string) {
 	const payload = c.get('jwtPayload')
 	const row = await c.env.SMOL_D1.prepare(`
-		SELECT Public, "Address" as Address
+		SELECT Id, Public, "Address" as Address
 		FROM Smols
 		WHERE Song_1 = ?1 OR Song_2 = ?1
 	`)
 		.bind(musicId)
-		.first<{ Public: number; Address: string | null }>()
+		.first<{ Id: string; Public: number; Address: string | null }>()
 
 	if (!row || (row.Public !== 1 && row.Address !== payload?.sub)) {
 		throw new HTTPException(404, { message: 'Song not found' })
@@ -62,8 +62,11 @@ media.get('/:id{.+\\.mp3}', optionalAuth, async (c) => {
 	headers.set('Content-Type', 'audio/mpeg')
 	headers.set(
 		'Cache-Control',
-		smol.Public === 1 ? 'public, max-age=31536000, immutable' : 'no-store'
+		smol.Public === 1 ? 'public, max-age=300, stale-while-revalidate=60' : 'no-store'
 	)
+	if (smol.Public === 1) {
+		headers.set('Cache-Tag', `smol:${smol.Id}:media`)
+	}
 
 	let status = 200
 	let body: ReadableStream | null = null
@@ -154,8 +157,9 @@ media.get(
 			headers: {
 				'Content-Type': 'image/png',
 				'Cache-Control': smol.Public === 1
-					? 'public, max-age=31536000, immutable'
+					? 'public, max-age=300, stale-while-revalidate=60'
 					: 'no-store',
+				...(smol.Public === 1 ? { 'Cache-Tag': `smol:${smolId}:media` } : {}),
 			},
 		})
 	}

--- a/src/api/media.ts
+++ b/src/api/media.ts
@@ -1,54 +1,30 @@
-import { Context, Hono } from 'hono'
+import { Hono } from 'hono'
 import { HTTPException } from 'hono/http-exception'
 import { Jimp, ResizeStrategy } from 'jimp'
 import type { HonoEnv } from '../types'
-import { optionalAuth } from '../middleware/auth'
 import { parseRange } from '../utils'
 
 const media = new Hono<HonoEnv>()
 
-async function getReadableSongRow(c: Context<HonoEnv>, musicId: string) {
-	const payload = c.get('jwtPayload')
-	const row = await c.env.SMOL_D1.prepare(`
-		SELECT Id, Public, "Address" as Address
+async function getSongSmolId(env: Env, musicId: string): Promise<string | null> {
+	const row = await env.SMOL_D1.prepare(`
+		SELECT Id
 		FROM Smols
 		WHERE Song_1 = ?1 OR Song_2 = ?1
 	`)
 		.bind(musicId)
-		.first<{ Id: string; Public: number; Address: string | null }>()
+		.first<{ Id: string }>()
 
-	if (!row || (row.Public !== 1 && row.Address !== payload?.sub)) {
-		throw new HTTPException(404, { message: 'Song not found' })
-	}
-
-	return row
-}
-
-async function getReadableImageRow(c: Context<HonoEnv>, smolId: string) {
-	const payload = c.get('jwtPayload')
-	const row = await c.env.SMOL_D1.prepare(`
-		SELECT Public, "Address" as Address
-		FROM Smols
-		WHERE Id = ?1
-	`)
-		.bind(smolId)
-		.first<{ Public: number; Address: string | null }>()
-
-	if (!row || (row.Public !== 1 && row.Address !== payload?.sub)) {
-		throw new HTTPException(404, { message: 'Image not found' })
-	}
-
-	return row
+	return row?.Id ?? null
 }
 
 // Serve songs
-media.get('/:id{.+\\.mp3}', optionalAuth, async (c) => {
+media.get('/:id{.+\\.mp3}', async (c) => {
 	const { env, req, executionCtx } = c
 	const id = req.param('id')
 	const musicId = id.replace(/\.mp3$/, '')
 	const rangeHeader = req.header('range')
-
-	const smol = await getReadableSongRow(c, musicId)
+	const smolId = await getSongSmolId(env, musicId)
 
 	const objectMeta = await env.SMOL_BUCKET.head(id)
 
@@ -60,12 +36,11 @@ media.get('/:id{.+\\.mp3}', optionalAuth, async (c) => {
 	objectMeta.writeHttpMetadata(headers)
 	headers.set('Accept-Ranges', 'bytes')
 	headers.set('Content-Type', 'audio/mpeg')
-	headers.set(
-		'Cache-Control',
-		smol.Public === 1 ? 'public, max-age=300, stale-while-revalidate=60' : 'no-store'
-	)
-	if (smol.Public === 1) {
-		headers.set('Cache-Tag', `smol:${smol.Id}:media`)
+	// Media URLs are intentionally link-shareable by opaque ID. Public/private
+	// controls listing and detail visibility, not direct asset playback.
+	headers.set('Cache-Control', 'public, max-age=300, stale-while-revalidate=60')
+	if (smolId) {
+		headers.set('Cache-Tag', `smol:${smolId}:media`)
 	}
 
 	let status = 200
@@ -117,14 +92,11 @@ media.get('/:id{.+\\.mp3}', optionalAuth, async (c) => {
 // Serve images
 media.get(
 	'/:id{.+\\.png}',
-	optionalAuth,
 	async (c) => {
 		const { env, req } = c
 		const id = req.param('id')
 		const smolId = id.replace(/\.png$/, '')
 		const scale = req.query('scale')
-
-		const smol = await getReadableImageRow(c, smolId)
 
 		const image = await env.SMOL_BUCKET.get(id)
 
@@ -156,10 +128,9 @@ media.get(
 		return new Response(scaled_image ?? image.body, {
 			headers: {
 				'Content-Type': 'image/png',
-				'Cache-Control': smol.Public === 1
-					? 'public, max-age=300, stale-while-revalidate=60'
-					: 'no-store',
-				...(smol.Public === 1 ? { 'Cache-Tag': `smol:${smolId}:media` } : {}),
+				// Media URLs are intentionally link-shareable by opaque ID.
+				'Cache-Control': 'public, max-age=300, stale-while-revalidate=60',
+				'Cache-Tag': `smol:${smolId}:media`,
 			},
 		})
 	}

--- a/src/api/media.ts
+++ b/src/api/media.ts
@@ -5,6 +5,7 @@ import type { HonoEnv } from '../types'
 import { parseRange } from '../utils'
 
 const media = new Hono<HonoEnv>()
+const MEDIA_CACHE_CONTROL = 'public, max-age=2592000, stale-while-revalidate=86400'
 
 async function getSongSmolId(env: Env, musicId: string): Promise<string | null> {
 	const row = await env.SMOL_D1.prepare(`
@@ -38,7 +39,7 @@ media.get('/:id{.+\\.mp3}', async (c) => {
 	headers.set('Content-Type', 'audio/mpeg')
 	// Media URLs are intentionally link-shareable by opaque ID. Public/private
 	// controls listing and detail visibility, not direct asset playback.
-	headers.set('Cache-Control', 'public, max-age=300, stale-while-revalidate=60')
+	headers.set('Cache-Control', MEDIA_CACHE_CONTROL)
 	if (smolId) {
 		headers.set('Cache-Tag', `smol:${smolId}:media`)
 	}
@@ -129,7 +130,7 @@ media.get(
 			headers: {
 				'Content-Type': 'image/png',
 				// Media URLs are intentionally link-shareable by opaque ID.
-				'Cache-Control': 'public, max-age=300, stale-while-revalidate=60',
+				'Cache-Control': MEDIA_CACHE_CONTROL,
 				'Cache-Tag': `smol:${smolId}:media`,
 			},
 		})

--- a/src/api/mint.ts
+++ b/src/api/mint.ts
@@ -1,19 +1,30 @@
 import { Hono } from 'hono'
 import { HTTPException } from 'hono/http-exception'
+import { xdr as stellarXdr } from '@stellar/stellar-sdk/minimal'
 import type { HonoEnv } from '../types'
 import { parseAuth } from '../middleware/auth'
 
 const mint = new Hono<HonoEnv>()
 const MAX_BATCH_MINT_IDS = 100
-const MAX_SIGNED_XDR_LENGTH = 10000
+// Current Mainnet Soroban contract_bandwidth_v0.tx_max_size_bytes.
+// Verified with `stellar network settings` on 2026-05-14; update if validators
+// change network transaction bandwidth limits.
+const MAX_SIGNED_XDR_BYTES = 132096
 
 function assertSignedXdr(value: unknown): string {
 	if (!value || typeof value !== 'string') {
 		throw new HTTPException(400, { message: 'Missing signed transaction' })
 	}
 
-	if (value.length > MAX_SIGNED_XDR_LENGTH) {
-		throw new HTTPException(400, { message: 'Signed transaction is too large' })
+	let byteLength: number
+	try {
+		byteLength = stellarXdr.TransactionEnvelope.fromXDR(value, 'base64').toXDR().length
+	} catch {
+		throw new HTTPException(400, { message: 'Invalid signed transaction XDR' })
+	}
+
+	if (byteLength > MAX_SIGNED_XDR_BYTES) {
+		throw new HTTPException(400, { message: `Signed transaction exceeds ${MAX_SIGNED_XDR_BYTES} bytes` })
 	}
 
 	return value
@@ -70,6 +81,7 @@ mint.post('/', parseAuth, async (c) => {
 		throw new HTTPException(404, { message: 'Some smols not found' })
 	}
 
+	const ownerSubsById: Record<string, string> = {}
 	for (const record of smolRecords.results) {
 		if (record.Mint_Token || record.Mint_Amm) {
 			throw new HTTPException(409, { message: `Smol ${record.Id} already minted` })
@@ -77,17 +89,19 @@ mint.post('/', parseAuth, async (c) => {
 		if (!record.Address) {
 			throw new HTTPException(404, { message: `Smol ${record.Id} not found` })
 		}
-		if (record.Address !== payload.sub) {
-			throw new HTTPException(403, { message: `Smol ${record.Id} not owned by you` })
-		}
+		ownerSubsById[record.Id] = record.Address
 	}
 
+	// Do not require Smols.Address to match the authenticated user. Minting is
+	// intentionally an artist/collector action, and public smols may be minted by
+	// people who did not create the original generated smol.
 	await env.TX_WORKFLOW.create({
 		params: {
 			type: 'batch-mint',
 			xdr,
 			ids,
 			sub: payload.sub,
+			ownerSubsById,
 		},
 	})
 
@@ -128,16 +142,16 @@ mint.post('/:id', parseAuth, async (c) => {
 		throw new HTTPException(404, { message: 'Smol not found' })
 	}
 
-	if (smolRecord.Address !== payload.sub) {
-		throw new HTTPException(403, { message: 'Smol not owned by you' })
-	}
-
+	// Do not require Smols.Address to match the authenticated user. Minting is
+	// intentionally an artist/collector action, and public smols may be minted by
+	// people who did not create the original generated smol.
 	await env.TX_WORKFLOW.create({
 		params: {
 			type: 'mint',
 			xdr,
 			entropy: id,
 			sub: payload.sub,
+			ownerSub: smolRecord.Address,
 		},
 	})
 

--- a/src/api/mint.ts
+++ b/src/api/mint.ts
@@ -81,15 +81,33 @@ mint.post('/', parseAuth, async (c) => {
 		throw new HTTPException(404, { message: 'Some smols not found' })
 	}
 
+	const recordsById = new Map(smolRecords.results.map((record) => [record.Id, record]))
 	const ownerSubsById: Record<string, string> = {}
-	for (const record of smolRecords.results) {
-		if (record.Mint_Token || record.Mint_Amm) {
-			throw new HTTPException(409, { message: `Smol ${record.Id} already minted` })
-		}
+	const mintableIds: string[] = []
+	const alreadyMintedIds: string[] = []
+
+	for (const id of ids) {
+		const record = recordsById.get(id)!
 		if (!record.Address) {
 			throw new HTTPException(404, { message: `Smol ${record.Id} not found` })
 		}
+
 		ownerSubsById[record.Id] = record.Address
+
+		if (record.Mint_Token || record.Mint_Amm) {
+			alreadyMintedIds.push(record.Id)
+		} else {
+			mintableIds.push(record.Id)
+		}
+	}
+
+	if (mintableIds.length === 0) {
+		return c.json({
+			acceptedIds: [],
+			skipped: {
+				alreadyMinted: alreadyMintedIds,
+			},
+		})
 	}
 
 	// Do not require Smols.Address to match the authenticated user. Minting is
@@ -100,12 +118,18 @@ mint.post('/', parseAuth, async (c) => {
 			type: 'batch-mint',
 			xdr,
 			ids,
+			mintableIds,
 			sub: payload.sub,
 			ownerSubsById,
 		},
 	})
 
-	return c.body(null, 202)
+	return c.json({
+		acceptedIds: mintableIds,
+		skipped: {
+			alreadyMinted: alreadyMintedIds,
+		},
+	}, 202)
 })
 
 mint.post('/:id', parseAuth, async (c) => {

--- a/src/api/mint.ts
+++ b/src/api/mint.ts
@@ -4,24 +4,56 @@ import type { HonoEnv } from '../types'
 import { parseAuth } from '../middleware/auth'
 
 const mint = new Hono<HonoEnv>()
+const MAX_BATCH_MINT_IDS = 100
+const MAX_SIGNED_XDR_LENGTH = 200000
+
+function assertSignedXdr(value: unknown): string {
+	if (!value || typeof value !== 'string') {
+		throw new HTTPException(400, { message: 'Missing signed transaction' })
+	}
+
+	if (value.length > MAX_SIGNED_XDR_LENGTH) {
+		throw new HTTPException(400, { message: 'Signed transaction is too large' })
+	}
+
+	return value
+}
+
+function assertMintIds(value: unknown): string[] {
+	if (!value || !Array.isArray(value) || value.length === 0) {
+		throw new HTTPException(400, { message: 'Missing or invalid ids array' })
+	}
+
+	if (value.length > MAX_BATCH_MINT_IDS) {
+		throw new HTTPException(400, { message: `Max ${MAX_BATCH_MINT_IDS} smols per batch mint` })
+	}
+
+	const ids = value.map((id) => {
+		if (typeof id !== 'string' || !id.trim()) {
+			throw new HTTPException(400, { message: 'Invalid smol id in ids array' })
+		}
+
+		return id.trim()
+	})
+
+	if (new Set(ids).size !== ids.length) {
+		throw new HTTPException(400, { message: 'Duplicate smol ids are not allowed' })
+	}
+
+	return ids
+}
 
 mint.post('/', parseAuth, async (c) => {
 	const { env, req } = c
 	const payload = c.get('jwtPayload')!
 	const body = await req.json() as { xdr?: string; ids?: string[] }
-
-	if (!body?.xdr || typeof body.xdr !== 'string') {
-		throw new HTTPException(400, { message: 'Missing signed transaction' })
-	}
-
-	if (!body?.ids || !Array.isArray(body.ids) || body.ids.length === 0) {
-		throw new HTTPException(400, { message: 'Missing or invalid ids array' })
-	}
+	const xdr = assertSignedXdr(body?.xdr)
+	const ids = assertMintIds(body?.ids)
 
 	const smolRecords = await env.SMOL_D1.prepare(
-		`SELECT Id, Title, Address, Mint_Token, Mint_Amm FROM Smols WHERE Id IN (${body.ids.map(() => '?').join(', ')})`
+		`SELECT Id, Title, Address, Mint_Token, Mint_Amm FROM Smols WHERE Id IN (${ids.map(() => '?').join(', ')})`
 	)
-		.bind(...body.ids)
+		.bind(...ids)
 		.all<{
 			Id: string
 			Title: string
@@ -34,7 +66,7 @@ mint.post('/', parseAuth, async (c) => {
 		throw new HTTPException(404, { message: 'No smols found' })
 	}
 
-	if (smolRecords.results.length !== body.ids.length) {
+	if (smolRecords.results.length !== ids.length) {
 		throw new HTTPException(404, { message: 'Some smols not found' })
 	}
 
@@ -45,13 +77,16 @@ mint.post('/', parseAuth, async (c) => {
 		if (!record.Address) {
 			throw new HTTPException(404, { message: `Smol ${record.Id} not found` })
 		}
+		if (record.Address !== payload.sub) {
+			throw new HTTPException(403, { message: `Smol ${record.Id} not owned by you` })
+		}
 	}
 
 	await env.TX_WORKFLOW.create({
 		params: {
 			type: 'batch-mint',
-			xdr: body.xdr,
-			ids: body.ids,
+			xdr,
+			ids,
 			sub: payload.sub,
 		},
 	})
@@ -64,13 +99,10 @@ mint.post('/:id', parseAuth, async (c) => {
 	const payload = c.get('jwtPayload')!
 	const id = req.param('id')
 	const body = await req.json() as { xdr?: string }
+	const xdr = assertSignedXdr(body?.xdr)
 
 	if (!id) {
 		throw new HTTPException(400, { message: 'Missing smol id' })
-	}
-
-	if (!body?.xdr || typeof body.xdr !== 'string') {
-		throw new HTTPException(400, { message: 'Missing signed transaction' })
 	}
 
 	const smolRecord = await env.SMOL_D1.prepare(
@@ -96,10 +128,14 @@ mint.post('/:id', parseAuth, async (c) => {
 		throw new HTTPException(404, { message: 'Smol not found' })
 	}
 
+	if (smolRecord.Address !== payload.sub) {
+		throw new HTTPException(403, { message: 'Smol not owned by you' })
+	}
+
 	await env.TX_WORKFLOW.create({
 		params: {
 			type: 'mint',
-			xdr: body.xdr,
+			xdr,
 			entropy: id,
 			sub: payload.sub,
 		},

--- a/src/api/mint.ts
+++ b/src/api/mint.ts
@@ -5,7 +5,7 @@ import { parseAuth } from '../middleware/auth'
 
 const mint = new Hono<HonoEnv>()
 const MAX_BATCH_MINT_IDS = 100
-const MAX_SIGNED_XDR_LENGTH = 200000
+const MAX_SIGNED_XDR_LENGTH = 10000
 
 function assertSignedXdr(value: unknown): string {
 	if (!value || typeof value !== 'string') {

--- a/src/api/mixtapes.ts
+++ b/src/api/mixtapes.ts
@@ -65,23 +65,25 @@ function assertStringLength(value: string, fieldName: string, maxLength: number)
 async function loadPublicSmolRows(env: Env, ids: string[]): Promise<Map<string, MixtapeSmolRow>> {
 	const uniqueIds = [...new Set(ids)].filter(Boolean)
 	const rows = new Map<string, MixtapeSmolRow>()
+	const batches: string[][] = []
 
 	for (let index = 0; index < uniqueIds.length; index += MAX_MIXTAPE_SMOLS) {
-		const batch = uniqueIds.slice(index, index + MAX_MIXTAPE_SMOLS)
-		if (batch.length === 0) {
-			continue
-		}
+		batches.push(uniqueIds.slice(index, index + MAX_MIXTAPE_SMOLS))
+	}
 
+	const results = await Promise.all(batches.map((batch) => {
 		const placeholders = batch.map(() => '?').join(',')
-		const { results } = await env.SMOL_D1.prepare(`
-			SELECT Id, Title, "Address" as Address, Mint_Token, Mint_Amm, Song_1
-			FROM Smols
-			WHERE Public = 1 AND Id IN (${placeholders})
-		`)
+		return env.SMOL_D1.prepare(`
+				SELECT Id, Title, "Address" as Address, Mint_Token, Mint_Amm, Song_1
+				FROM Smols
+				WHERE Public = 1 AND Id IN (${placeholders})
+			`)
 			.bind(...batch)
 			.all<MixtapeSmolRow>()
+	}))
 
-		for (const row of results) {
+	for (const result of results) {
+		for (const row of result.results) {
 			rows.set(row.Id, row)
 		}
 	}

--- a/src/api/mixtapes.ts
+++ b/src/api/mixtapes.ts
@@ -6,6 +6,88 @@ import { parseAuth } from '../middleware/auth'
 import { purgeMixtapesCache } from '../utils/cache'
 
 const mixtapes = new Hono<HonoEnv>()
+const MAX_MIXTAPE_TITLE_LENGTH = 120
+const MAX_MIXTAPE_DESC_LENGTH = 1000
+const MAX_MIXTAPE_SMOLS = 100
+
+interface MixtapeRow {
+	Id: string
+	Title: string
+	Desc: string
+	Smols: string
+	Address: string
+	Created_At: string
+}
+
+interface MixtapeSmolRow {
+	Id: string
+	Title: string
+	Address: string
+	Mint_Token: string | null
+	Mint_Amm: string | null
+	Song_1: string
+}
+
+function parseStoredSmolIds(smols: string): string[] {
+	return smols.split(',').map((id) => id.trim()).filter(Boolean)
+}
+
+function parseRequestedSmolIds(value: unknown): string[] {
+	if (!Array.isArray(value) || value.length === 0) {
+		throw new HTTPException(400, { message: 'Missing or invalid smols array' })
+	}
+
+	if (value.length > MAX_MIXTAPE_SMOLS) {
+		throw new HTTPException(400, { message: `Max ${MAX_MIXTAPE_SMOLS} smols per mixtape` })
+	}
+
+	const ids = value.map((id) => {
+		if (typeof id !== 'string' || !id.trim() || id.includes(',') || id.includes('"')) {
+			throw new HTTPException(400, { message: 'Invalid smol id in mixtape' })
+		}
+
+		return id.trim()
+	})
+
+	if (new Set(ids).size !== ids.length) {
+		throw new HTTPException(400, { message: 'Duplicate smol ids are not allowed' })
+	}
+
+	return ids
+}
+
+function assertStringLength(value: string, fieldName: string, maxLength: number) {
+	if (value.length > maxLength) {
+		throw new HTTPException(400, { message: `${fieldName} must be ${maxLength} characters or less` })
+	}
+}
+
+async function loadPublicSmolRows(env: Env, ids: string[]): Promise<Map<string, MixtapeSmolRow>> {
+	const uniqueIds = [...new Set(ids)].filter(Boolean)
+	const rows = new Map<string, MixtapeSmolRow>()
+
+	for (let index = 0; index < uniqueIds.length; index += MAX_MIXTAPE_SMOLS) {
+		const batch = uniqueIds.slice(index, index + MAX_MIXTAPE_SMOLS)
+		if (batch.length === 0) {
+			continue
+		}
+
+		const placeholders = batch.map(() => '?').join(',')
+		const { results } = await env.SMOL_D1.prepare(`
+			SELECT Id, Title, "Address" as Address, Mint_Token, Mint_Amm, Song_1
+			FROM Smols
+			WHERE Public = 1 AND Id IN (${placeholders})
+		`)
+			.bind(...batch)
+			.all<MixtapeSmolRow>()
+
+		for (const row of results) {
+			rows.set(row.Id, row)
+		}
+	}
+
+	return rows
+}
 
 // Create new mixtape
 mixtapes.post('/', parseAuth, async (c) => {
@@ -20,16 +102,20 @@ mixtapes.post('/', parseAuth, async (c) => {
 	if (!body.title || typeof body.title !== 'string') {
 		throw new HTTPException(400, { message: 'Missing or invalid title' })
 	}
+	assertStringLength(body.title, 'Title', MAX_MIXTAPE_TITLE_LENGTH)
 
 	if (!body.desc || typeof body.desc !== 'string') {
 		throw new HTTPException(400, { message: 'Missing or invalid description' })
 	}
+	assertStringLength(body.desc, 'Description', MAX_MIXTAPE_DESC_LENGTH)
 
-	if (!Array.isArray(body.smols) || body.smols.length === 0) {
-		throw new HTTPException(400, { message: 'Missing or invalid smols array' })
+	const smolIds = parseRequestedSmolIds(body.smols)
+	const publicSmolRows = await loadPublicSmolRows(env, smolIds)
+	if (publicSmolRows.size !== smolIds.length) {
+		throw new HTTPException(400, { message: 'Mixtapes can only include public smols' })
 	}
 
-	const smolsString = body.smols.join(',')
+	const smolsString = smolIds.join(',')
 
 	const result = await env.SMOL_D1.prepare(`
 		INSERT INTO Mixtapes (Title, Desc, Smols, "Address")
@@ -62,18 +148,14 @@ mixtapes.get(
 			FROM Mixtapes
 			ORDER BY Created_At DESC
 			LIMIT 100
-		`).all<{
-			Id: string
-			Title: string
-			Desc: string
-			Smols: string
-			Address: string
-			Created_At: string
-		}>()
+		`).all<MixtapeRow>()
+
+		const allSmolIds = results.flatMap((mixtape) => parseStoredSmolIds(mixtape.Smols))
+		const publicSmolRows = await loadPublicSmolRows(env, allSmolIds)
 
 		const mixtapes = results.map((mixtape) => ({
 			...mixtape,
-			Smols: mixtape.Smols.split(','),
+			Smols: parseStoredSmolIds(mixtape.Smols).filter((id) => publicSmolRows.has(id)),
 		}))
 
 		const response = c.json(mixtapes)
@@ -96,72 +178,50 @@ mixtapes.get(
 		const { env } = c
 		const id = c.req.param('id')
 
-		const { results } = await env.SMOL_D1.prepare(`
-			SELECT
-				m.Id,
-				m.Title,
-				m.Desc,
-				m."Address",
-				m.Created_At,
-				s.Id as Smol_Id,
-				s.Title as Smol_Title,
-				s."Address" as Smol_Address,
-				s.Mint_Token,
-				s.Mint_Amm,
-				s.Song_1
-			FROM Mixtapes m
-			CROSS JOIN json_each('["' || replace(m.Smols, ',', '","') || '"]') as smol_ids
-			LEFT JOIN Smols s ON s.Id = smol_ids.value
-			WHERE m.Id = ?1
+		const mixtapeRow = await env.SMOL_D1.prepare(`
+			SELECT Id, Title, Desc, Smols, "Address", Created_At
+			FROM Mixtapes
+			WHERE Id = ?1
 		`)
 			.bind(id)
-			.all<{
-				Id: string
-				Title: string
-				Desc: string
-				Address: string
-				Created_At: string
-				Smol_Id: string | null
-				Smol_Title: string | null
-				Smol_Address: string | null
-				Mint_Token: string | null
-				Mint_Amm: string | null
-				Song_1: string | null
-			}>()
+			.first<MixtapeRow>()
 
-		if (results.length === 0) {
+		if (!mixtapeRow) {
 			throw new HTTPException(404, { message: 'Mixtape not found' })
 		}
 
+		const smolIds = parseStoredSmolIds(mixtapeRow.Smols)
+		const publicSmolRows = await loadPublicSmolRows(env, smolIds)
+		const smolRows = smolIds.map((smolId) => publicSmolRows.get(smolId)).filter((row): row is MixtapeSmolRow => Boolean(row))
+
 		// Fetch KV data in bulk (up to 100 keys at once)
-		const smolIds = results
-			.filter((row) => row.Smol_Id !== null)
-			.map((row) => row.Smol_Id!)
+		const publicSmolIds = smolRows.map((row) => row.Id)
 
-		const kvData = await env.SMOL_KV.get<SmolKVData>(smolIds, 'json')
+		const kvData = publicSmolIds.length > 0
+			? await env.SMOL_KV.get<SmolKVData>(publicSmolIds, 'json')
+			: new Map<string, SmolKVData | null>()
 
-		const smolsWithKV = results
-			.filter((row) => row.Smol_Id !== null)
+		const smolsWithKV = smolRows
 			.map((row) => {
-				const kv = kvData.get(row.Smol_Id!)
+				const kv = kvData.get(row.Id)
 				return {
-					Id: row.Smol_Id!,
-					Title: row.Smol_Title!,
-					Address: row.Smol_Address!,
+					Id: row.Id,
+					Title: row.Title,
+					Address: row.Address,
 					Mint_Token: row.Mint_Token,
 					Mint_Amm: row.Mint_Amm,
-					Song_1: row.Song_1!,
+					Song_1: row.Song_1,
 					Tags: kv?.lyrics?.style || [],
 				}
 			})
 
 		// Take mixtape data from first row
 		const mixtape = {
-			Id: results[0].Id,
-			Title: results[0].Title,
-			Desc: results[0].Desc,
-			Address: results[0].Address,
-			Created_At: results[0].Created_At,
+			Id: mixtapeRow.Id,
+			Title: mixtapeRow.Title,
+			Desc: mixtapeRow.Desc,
+			Address: mixtapeRow.Address,
+			Created_At: mixtapeRow.Created_At,
 			Smols: smolsWithKV,
 		}
 

--- a/src/api/smols.ts
+++ b/src/api/smols.ts
@@ -372,20 +372,19 @@ smols.post('/', parseAuth, async (c) => {
 // Retry smol creation
 smols.post('/retry/:id', parseAuth, async (c) => {
 	const { env, req } = c
-	const payload = c.get('jwtPayload')!
 
 	const id = req.param('id')
 
 	const smol = await env.SMOL_D1.prepare(`
 		SELECT Id
 		FROM Smols
-		WHERE Id = ?1 AND "Address" = ?2
+		WHERE Id = ?1
 	`)
-		.bind(id, payload.sub)
+		.bind(id)
 		.first<{ Id: string }>()
 
 	if (!smol) {
-		throw new HTTPException(404, { message: 'Smol not found or not owned by you' })
+		throw new HTTPException(404, { message: 'Smol not found' })
 	}
 
 	const instanceId = env.DURABLE_OBJECT.newUniqueId().toString()

--- a/src/api/smols.ts
+++ b/src/api/smols.ts
@@ -38,6 +38,26 @@ interface SmolD1Record {
 	[key: string]: unknown
 }
 
+async function hasRetryableSmolState(env: Env, id: string): Promise<boolean> {
+	let retrySteps: any
+
+	if (isDurableObjectId(id)) {
+		try {
+			const doid = env.DURABLE_OBJECT.idFromString(id)
+			const stub = env.DURABLE_OBJECT.get(doid)
+			retrySteps = await stub.getSteps()
+		} catch {
+			retrySteps = undefined
+		}
+	}
+
+	if (!retrySteps?.payload) {
+		retrySteps = await env.SMOL_KV.get(id, 'json')
+	}
+
+	return !!(retrySteps?.payload?.address && retrySteps?.payload?.prompt)
+}
+
 // Get all public smols
 smols.get(
 	'/',
@@ -374,15 +394,7 @@ smols.post('/retry/:id', async (c) => {
 
 	const id = req.param('id')
 
-	const smol = await env.SMOL_D1.prepare(`
-		SELECT Id
-		FROM Smols
-		WHERE Id = ?1
-	`)
-		.bind(id)
-		.first<{ Id: string }>()
-
-	if (!smol) {
+	if (!await hasRetryableSmolState(env, id)) {
 		throw new HTTPException(404, { message: 'Smol not found' })
 	}
 

--- a/src/api/smols.ts
+++ b/src/api/smols.ts
@@ -176,7 +176,7 @@ smols.get(
 		const payload = c.get('jwtPayload')!
 		const { limit, cursor } = parsePaginationParams(new URL(req.url))
 
-	const whereClause = buildCursorWhereClause(cursor, 'l."Address" = ? AND s.Public = 1', 's.')
+	const whereClause = buildCursorWhereClause(cursor, 'l."Address" = ?', 's.')
 	const bindings: any[] = []
 
 	let query: string
@@ -243,10 +243,6 @@ smols.get(
 			.first<SmolD1Record>()
 
 		if (smol_d1) {
-			if (smol_d1.Public !== 1 && smol_d1.Address !== payload?.sub) {
-				throw new HTTPException(404, { message: 'Smol not found' })
-			}
-
 			if (payload?.sub) {
 				const likedRow = await env.SMOL_D1.prepare(
 					`SELECT 1 FROM Likes WHERE Id = ?1 AND "Address" = ?2`
@@ -276,9 +272,7 @@ smols.get(
 				liked,
 			})
 
-			if (smol_d1.Public !== 1) {
-				response.headers.set('Cache-Control', 'no-store')
-			} else if (payload?.sub) {
+			if (payload?.sub) {
 				response.headers.set('Cache-Control', 'private, max-age=30')
 			} else {
 				response.headers.set('Cache-Control', 'public, max-age=30, stale-while-revalidate=60')

--- a/src/api/smols.ts
+++ b/src/api/smols.ts
@@ -17,6 +17,7 @@ import { queueSearchDeletionById } from '../utils/search'
 import { requireOwnedVisibilityToggle, syncSearchVisibilityAfterToggle } from '../utils/search-visibility'
 
 const smols = new Hono<HonoEnv>()
+const MAX_PROMPT_LENGTH = 2000
 
 interface SmolListItem {
 	Id: string
@@ -319,8 +320,12 @@ smols.post('/', parseAuth, async (c) => {
 		playlist?: string
 	} = await req.json()
 
-	if (!body.prompt) {
+	if (!body.prompt || typeof body.prompt !== 'string') {
 		throw new HTTPException(400, { message: 'Missing prompt' })
+	}
+
+	if (body.prompt.length > MAX_PROMPT_LENGTH) {
+		throw new HTTPException(400, { message: `Prompt must be ${MAX_PROMPT_LENGTH} characters or less` })
 	}
 
 	const instanceId = env.DURABLE_OBJECT.newUniqueId().toString()
@@ -344,8 +349,22 @@ smols.post('/', parseAuth, async (c) => {
 // Retry smol creation
 smols.post('/retry/:id', parseAuth, async (c) => {
 	const { env, req } = c
+	const payload = c.get('jwtPayload')!
 
 	const id = req.param('id')
+
+	const smol = await env.SMOL_D1.prepare(`
+		SELECT Id
+		FROM Smols
+		WHERE Id = ?1 AND "Address" = ?2
+	`)
+		.bind(id, payload.sub)
+		.first<{ Id: string }>()
+
+	if (!smol) {
+		throw new HTTPException(404, { message: 'Smol not found or not owned by you' })
+	}
+
 	const instanceId = env.DURABLE_OBJECT.newUniqueId().toString()
 	const instance = await env.WORKFLOW.create({
 		id: instanceId,
@@ -364,6 +383,18 @@ smols.put('/:id', parseAuth, async (c) => {
 	const { env, req } = c
 	const id = req.param('id')
 	const payload = c.get('jwtPayload')!
+
+	const smolRecord = await env.SMOL_D1.prepare(`
+		SELECT Public
+		FROM Smols
+		WHERE Id = ?1 AND "Address" = ?2
+	`)
+		.bind(id, payload.sub)
+		.first<{ Public: number }>()
+
+	if (!smolRecord) {
+		throw new HTTPException(404, { message: 'Smol not found or not owned by you' })
+	}
 
 	const smol_kv: any = await env.SMOL_KV.get(id, 'json')
 
@@ -409,7 +440,12 @@ smols.put('/:id', parseAuth, async (c) => {
 
 	// Purge user's individual page
 	c.executionCtx.waitUntil(
-		purgeCacheByTags([`user:${payload.sub}:smol:${id}`])
+		purgeCacheByTags([
+			'public-smols',
+			`user:${payload.sub}:created`,
+			`user:${payload.sub}:smol:${id}`,
+			`smol:${id}:anonymous`,
+		])
 	)
 
 	return c.body(null, 204)
@@ -559,6 +595,7 @@ smols.delete('/:id', parseAuth, async (c) => {
 
 	await env.SMOL_KV.delete(id)
 	await env.SMOL_BUCKET.delete(`${id}.png`)
+	await env.SMOL_D1.prepare(`DELETE FROM Likes WHERE Id = ?1`).bind(id).run()
 
 	if (smol) {
 		for (let song of smol.songs) {
@@ -580,8 +617,10 @@ smols.delete('/:id', parseAuth, async (c) => {
 	// Purge user's created list and individual page
 	c.executionCtx.waitUntil(
 		purgeCacheByTags([
+			'public-smols',
 			`user:${payload.sub}:created`,
 			`user:${payload.sub}:smol:${id}`,
+			`smol:${id}:anonymous`,
 		])
 	)
 

--- a/src/api/smols.ts
+++ b/src/api/smols.ts
@@ -18,7 +18,9 @@ import { queueSearchDeletionById } from '../utils/search'
 import { requireOwnedVisibilityToggle, syncSearchVisibilityAfterToggle } from '../utils/search-visibility'
 
 const smols = new Hono<HonoEnv>()
-const MAX_PROMPT_LENGTH = 2000
+// Keep these in sync with smol-fe generation controls and provider payload limits.
+const MAX_LYRICAL_PROMPT_LENGTH = 2280
+const MAX_INSTRUMENTAL_PROMPT_LENGTH = 380
 
 interface SmolListItem {
 	Id: string
@@ -347,8 +349,11 @@ smols.post('/', parseAuth, async (c) => {
 		throw new HTTPException(400, { message: 'Missing prompt' })
 	}
 
-	if (body.prompt.length > MAX_PROMPT_LENGTH) {
-		throw new HTTPException(400, { message: `Prompt must be ${MAX_PROMPT_LENGTH} characters or less` })
+	const isInstrumental = body.instrumental ?? false
+	const maxPromptLength = isInstrumental ? MAX_INSTRUMENTAL_PROMPT_LENGTH : MAX_LYRICAL_PROMPT_LENGTH
+
+	if (body.prompt.length > maxPromptLength) {
+		throw new HTTPException(400, { message: `Prompt must be ${maxPromptLength} characters or less` })
 	}
 
 	const instanceId = env.DURABLE_OBJECT.newUniqueId().toString()
@@ -358,7 +363,7 @@ smols.post('/', parseAuth, async (c) => {
 			address: payload.sub,
 			prompt: body.prompt,
 			public: body.public ?? true,
-			instrumental: body.instrumental ?? false,
+			instrumental: isInstrumental,
 			playlist: body.playlist,
 		},
 	})

--- a/src/api/smols.ts
+++ b/src/api/smols.ts
@@ -369,7 +369,7 @@ smols.post('/', parseAuth, async (c) => {
 })
 
 // Retry smol creation
-smols.post('/retry/:id', parseAuth, async (c) => {
+smols.post('/retry/:id', async (c) => {
 	const { env, req } = c
 
 	const id = req.param('id')

--- a/src/api/smols.ts
+++ b/src/api/smols.ts
@@ -102,7 +102,7 @@ smols.get(
 	parseAuth,
 	cache({
 		cacheName: 'smol-workflow',
-		cacheControl: 'public, max-age=30, stale-while-revalidate=60',
+		cacheControl: 'private, max-age=30',
 		keyGenerator: userCacheKeyGenerator, // Each user gets separate cache via sub claim
 	}),
 	async (c) => {
@@ -110,7 +110,7 @@ smols.get(
 		const payload = c.get('jwtPayload')!
 		const { limit, cursor } = parsePaginationParams(new URL(req.url))
 
-	const whereClause = buildCursorWhereClause(cursor, 'Address = ?')
+	const whereClause = buildCursorWhereClause(cursor, '"Address" = ?')
 	const bindings: any[] = []
 
 	let query: string
@@ -165,7 +165,7 @@ smols.get(
 	parseAuth,
 	cache({
 		cacheName: 'smol-workflow',
-		cacheControl: 'public, max-age=30, stale-while-revalidate=60',
+		cacheControl: 'private, max-age=30',
 		keyGenerator: userCacheKeyGenerator, // Each user gets separate cache via sub claim
 	}),
 	async (c) => {
@@ -232,18 +232,8 @@ smols.get(
 		const { env, req, executionCtx } = c
 		const id = req.param('id')
 
-		// Determine if requester has liked the smol (if authenticated)
 		const payload = c.get('jwtPayload')
 		let liked = false
-		if (payload?.sub) {
-			const likedRow = await env.SMOL_D1.prepare(
-				`SELECT 1 FROM Likes WHERE Id = ?1 AND "Address" = ?2`
-			)
-				.bind(id, payload.sub)
-				.first()
-
-			liked = !!likedRow
-		}
 
 		const smol_d1 = await env.SMOL_D1.prepare(`SELECT * FROM Smols WHERE Id = ?1`)
 			.bind(id)
@@ -252,6 +242,16 @@ smols.get(
 		if (smol_d1) {
 			if (smol_d1.Public !== 1 && smol_d1.Address !== payload?.sub) {
 				throw new HTTPException(404, { message: 'Smol not found' })
+			}
+
+			if (payload?.sub) {
+				const likedRow = await env.SMOL_D1.prepare(
+					`SELECT 1 FROM Likes WHERE Id = ?1 AND "Address" = ?2`
+				)
+					.bind(id, payload.sub)
+					.first()
+
+				liked = !!likedRow
 			}
 
 			const smol_kv: any = await env.SMOL_KV.get(id, 'json')
@@ -310,7 +310,7 @@ smols.get(
 
 		const steps = (await stub.getSteps()) as any || {}
 
-		if (steps?.payload?.address !== payload?.sub) {
+		if (!payload?.sub || steps?.payload?.address !== payload.sub) {
 			throw new HTTPException(404, { message: 'Smol not found' })
 		}
 
@@ -468,6 +468,7 @@ smols.put('/:id', parseAuth, async (c) => {
 			`user:${payload.sub}:created`,
 			`user:${payload.sub}:smol:${id}`,
 			`smol:${id}:anonymous`,
+			`smol:${id}:media`,
 		])
 	)
 
@@ -550,8 +551,8 @@ smols.delete('/admin/bulk', parseAuth, async (c) => {
 		const likeRows = await env.SMOL_D1.prepare(`SELECT "Address" as Address FROM Likes WHERE Id = ?1`)
 			.bind(id)
 			.all<{ Address: string }>()
-		await env.SMOL_D1.prepare(`DELETE FROM Smols WHERE Id = ?1`).bind(id).run()
 		await env.SMOL_D1.prepare(`DELETE FROM Likes WHERE Id = ?1`).bind(id).run()
+		await env.SMOL_D1.prepare(`DELETE FROM Smols WHERE Id = ?1`).bind(id).run()
 
 		const smolKv: any = await env.SMOL_KV.get(id, 'json')
 
@@ -584,6 +585,7 @@ smols.delete('/admin/bulk', parseAuth, async (c) => {
 				`user:${smol.Address}:created`,
 				`user:${smol.Address}:smol:${id}`,
 				`smol:${id}:anonymous`,
+				`smol:${id}:media`,
 				...((likeRows.results || []).flatMap((like) => [
 					`user:${like.Address}:liked`,
 					`user:${like.Address}:likes`,
@@ -603,15 +605,15 @@ smols.delete('/:id', parseAuth, async (c) => {
 	const id = req.param('id')
 	const payload = c.get('jwtPayload')!
 
-	// Check ownership and delete in one query
-	const result = await env.SMOL_D1.prepare(`
-		DELETE FROM Smols
+	const ownedSmol = await env.SMOL_D1.prepare(`
+		SELECT Id
+		FROM Smols
 		WHERE Id = ?1 AND "Address" = ?2
 	`)
 		.bind(id, payload.sub)
-		.run()
+		.first<{ Id: string }>()
 
-	if (result.meta.changes === 0) {
+	if (!ownedSmol) {
 		throw new HTTPException(404, { message: 'Smol not found or not owned by you' })
 	}
 
@@ -620,6 +622,11 @@ smols.delete('/:id', parseAuth, async (c) => {
 		.all<{ Address: string }>()
 
 	const smol: any = await env.SMOL_KV.get(id, 'json')
+
+	await env.SMOL_D1.prepare(`DELETE FROM Likes WHERE Id = ?1`).bind(id).run()
+	await env.SMOL_D1.prepare(`DELETE FROM Smols WHERE Id = ?1 AND "Address" = ?2`)
+		.bind(id, payload.sub)
+		.run()
 
 	try {
 		if (isDurableObjectId(id)) {
@@ -631,7 +638,6 @@ smols.delete('/:id', parseAuth, async (c) => {
 
 	await env.SMOL_KV.delete(id)
 	await env.SMOL_BUCKET.delete(`${id}.png`)
-	await env.SMOL_D1.prepare(`DELETE FROM Likes WHERE Id = ?1`).bind(id).run()
 
 	if (smol) {
 		for (let song of smol.songs) {
@@ -658,6 +664,7 @@ smols.delete('/:id', parseAuth, async (c) => {
 			`user:${payload.sub}:created`,
 			`user:${payload.sub}:smol:${id}`,
 			`smol:${id}:anonymous`,
+			`smol:${id}:media`,
 			...((likeRows.results || []).flatMap((like) => [
 				`user:${like.Address}:liked`,
 				`user:${like.Address}:likes`,

--- a/src/api/smols.ts
+++ b/src/api/smols.ts
@@ -28,6 +28,13 @@ interface SmolListItem {
 	Created_At: string
 }
 
+interface SmolD1Record {
+	Id: string
+	Public: number
+	Address: string | null
+	[key: string]: unknown
+}
+
 // Get all public smols
 smols.get(
 	'/',
@@ -166,7 +173,7 @@ smols.get(
 		const payload = c.get('jwtPayload')!
 		const { limit, cursor } = parsePaginationParams(new URL(req.url))
 
-	const whereClause = buildCursorWhereClause(cursor, 'l."Address" = ?', 's.')
+	const whereClause = buildCursorWhereClause(cursor, 'l."Address" = ? AND s.Public = 1', 's.')
 	const bindings: any[] = []
 
 	let query: string
@@ -240,9 +247,13 @@ smols.get(
 
 		const smol_d1 = await env.SMOL_D1.prepare(`SELECT * FROM Smols WHERE Id = ?1`)
 			.bind(id)
-			.first()
+			.first<SmolD1Record>()
 
 		if (smol_d1) {
+			if (smol_d1.Public !== 1 && smol_d1.Address !== payload?.sub) {
+				throw new HTTPException(404, { message: 'Smol not found' })
+			}
+
 			const smol_kv: any = await env.SMOL_KV.get(id, 'json')
 
 			// Increment views non-blockingly
@@ -262,8 +273,13 @@ smols.get(
 				liked,
 			})
 
-			// Only cache completed SMOLs (those in D1)
-			response.headers.set('Cache-Control', 'public, max-age=30, stale-while-revalidate=60')
+			if (smol_d1.Public !== 1) {
+				response.headers.set('Cache-Control', 'no-store')
+			} else if (payload?.sub) {
+				response.headers.set('Cache-Control', 'private, max-age=30')
+			} else {
+				response.headers.set('Cache-Control', 'public, max-age=30, stale-while-revalidate=60')
+			}
 
 			// Add cache tags for individual smol
 			// Use user-specific tag if authenticated, so we only purge that user's cache entry
@@ -292,8 +308,14 @@ smols.get(
 			}
 		})
 
+		const steps = (await stub.getSteps()) as any || {}
+
+		if (steps?.payload?.address !== payload?.sub) {
+			throw new HTTPException(404, { message: 'Smol not found' })
+		}
+
 		// Replace image_base64 with boolean marker (interfaces use this to know when image is ready)
-		const { image_base64, ...rest } = (await stub.getSteps()) as any || {}
+		const { image_base64, ...rest } = steps
 		const kv_do = { ...rest, image: !!image_base64 }
 
 		const response = c.json({
@@ -442,6 +464,7 @@ smols.put('/:id', parseAuth, async (c) => {
 	c.executionCtx.waitUntil(
 		purgeCacheByTags([
 			'public-smols',
+			'mixtapes',
 			`user:${payload.sub}:created`,
 			`user:${payload.sub}:smol:${id}`,
 			`smol:${id}:anonymous`,
@@ -524,6 +547,9 @@ smols.delete('/admin/bulk', parseAuth, async (c) => {
 			continue
 		}
 
+		const likeRows = await env.SMOL_D1.prepare(`SELECT "Address" as Address FROM Likes WHERE Id = ?1`)
+			.bind(id)
+			.all<{ Address: string }>()
 		await env.SMOL_D1.prepare(`DELETE FROM Smols WHERE Id = ?1`).bind(id).run()
 		await env.SMOL_D1.prepare(`DELETE FROM Likes WHERE Id = ?1`).bind(id).run()
 
@@ -553,9 +579,15 @@ smols.delete('/admin/bulk', parseAuth, async (c) => {
 		// Purge caches for this smol's owner
 		c.executionCtx.waitUntil(
 			purgeCacheByTags([
+				'public-smols',
+				'mixtapes',
 				`user:${smol.Address}:created`,
 				`user:${smol.Address}:smol:${id}`,
 				`smol:${id}:anonymous`,
+				...((likeRows.results || []).flatMap((like) => [
+					`user:${like.Address}:liked`,
+					`user:${like.Address}:likes`,
+				])),
 			])
 		)
 
@@ -582,6 +614,10 @@ smols.delete('/:id', parseAuth, async (c) => {
 	if (result.meta.changes === 0) {
 		throw new HTTPException(404, { message: 'Smol not found or not owned by you' })
 	}
+
+	const likeRows = await env.SMOL_D1.prepare(`SELECT "Address" as Address FROM Likes WHERE Id = ?1`)
+		.bind(id)
+		.all<{ Address: string }>()
 
 	const smol: any = await env.SMOL_KV.get(id, 'json')
 
@@ -618,9 +654,14 @@ smols.delete('/:id', parseAuth, async (c) => {
 	c.executionCtx.waitUntil(
 		purgeCacheByTags([
 			'public-smols',
+			'mixtapes',
 			`user:${payload.sub}:created`,
 			`user:${payload.sub}:smol:${id}`,
 			`smol:${id}:anonymous`,
+			...((likeRows.results || []).flatMap((like) => [
+				`user:${like.Address}:liked`,
+				`user:${like.Address}:likes`,
+			])),
 		])
 	)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,11 +19,37 @@ import { processSearchQueue, processSearchDLQ, runSearchBackfillCron } from './u
 
 export const app = new Hono<HonoEnv>()
 
+const DEV_CORS_ORIGINS = new Set([
+	'http://localhost:3000',
+	'http://localhost:5173',
+	'http://127.0.0.1:3000',
+	'http://127.0.0.1:5173',
+])
+
+function allowedCorsOrigin(origin: string): string | null {
+	if (!origin) {
+		return null
+	}
+
+	try {
+		const url = new URL(origin)
+		const isSmolOrigin = url.protocol === 'https:' && (url.hostname === 'smol.xyz' || url.hostname.endsWith('.smol.xyz'))
+
+		if (isSmolOrigin || DEV_CORS_ORIGINS.has(origin)) {
+			return origin
+		}
+	} catch {
+		return null
+	}
+
+	return null
+}
+
 // Global CORS middleware
 app.use(
 	'*',
 	cors({
-		origin: (origin) => origin ?? '*',
+		origin: (origin) => allowedCorsOrigin(origin),
 		credentials: true,
 	})
 )

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -4,6 +4,14 @@ import { getCookie } from 'hono/cookie'
 import { HTTPException } from 'hono/http-exception'
 import type { HonoEnv } from '../types'
 
+async function verifyJwtOrThrow(token: string, secret: string) {
+	try {
+		return await verify(token, secret, 'HS256')
+	} catch {
+		throw new HTTPException(401, { message: 'Invalid token' })
+	}
+}
+
 /**
  * Required authentication middleware
  * Throws 401 if no valid token is found
@@ -18,7 +26,7 @@ export async function parseAuth(c: Context<HonoEnv>, next: Next) {
 			// Admin token
 			c.set('isAdmin', true)
 		} else if (token) {
-			c.set('jwtPayload', await verify(token, c.env.SECRET, 'HS256'))
+			c.set('jwtPayload', await verifyJwtOrThrow(token, c.env.SECRET))
 		} else {
 			throw new HTTPException(401, { message: 'Invalid "Authorization" header' })
 		}
@@ -26,7 +34,7 @@ export async function parseAuth(c: Context<HonoEnv>, next: Next) {
 		const token = getCookie(c, 'smol_token')
 
 		if (token) {
-			c.set('jwtPayload', await verify(token, c.env.SECRET, 'HS256'))
+			c.set('jwtPayload', await verifyJwtOrThrow(token, c.env.SECRET))
 		} else {
 			throw new HTTPException(401, { message: 'Invalid "Cookie" token' })
 		}

--- a/src/tx-workflow.ts
+++ b/src/tx-workflow.ts
@@ -128,8 +128,20 @@ export class TxWorkflow extends WorkflowEntrypoint<Env, WorkflowTxParams> {
         } else if (event.payload.type === 'batch-mint') {
             await step.do('persist batch mint metadata', config, async () => {
                 const results = scValToNative(xdr.ScVal.fromXDR(res.returnValue, 'base64')) as [string, string][];
+                const requestedIds = event.payload.ids ?? [];
+                const mintableIds = event.payload.mintableIds ?? requestedIds;
 
-                if (!Array.isArray(results) || results.length !== event.payload.ids?.length) {
+                if (!Array.isArray(results)) {
+                    throw new NonRetryableError('Batch mint result is not a list');
+                }
+
+                const resultIds = results.length === requestedIds.length
+                    ? requestedIds
+                    : results.length === mintableIds.length
+                        ? mintableIds
+                        : null;
+
+                if (!resultIds) {
                     throw new NonRetryableError('Batch mint result count does not match requested smol count');
                 }
 
@@ -138,7 +150,7 @@ export class TxWorkflow extends WorkflowEntrypoint<Env, WorkflowTxParams> {
 
                 for (let i = 0; i < results.length; i++) {
                     const [tokenSACAddress, cometAMMAddress] = results[i];
-                    const id = event.payload.ids![i];
+                    const id = resultIds[i];
 
                     const result = await this.env.SMOL_D1.prepare(`
                         UPDATE Smols

--- a/src/tx-workflow.ts
+++ b/src/tx-workflow.ts
@@ -120,6 +120,10 @@ export class TxWorkflow extends WorkflowEntrypoint<Env, WorkflowTxParams> {
             await step.do('persist batch mint metadata', config, async () => {
                 const results = scValToNative(xdr.ScVal.fromXDR(res.returnValue, 'base64')) as [string, string][];
 
+                if (!Array.isArray(results) || results.length !== event.payload.ids?.length) {
+                    throw new NonRetryableError('Batch mint result count does not match requested smol count');
+                }
+
                 // Collect smol IDs for cache purging
                 const smolCacheTags: string[] = [];
 
@@ -136,7 +140,7 @@ export class TxWorkflow extends WorkflowEntrypoint<Env, WorkflowTxParams> {
                         .run();
 
                     if (result.meta.changes === 0) {
-                        throw new NonRetryableError(`Smol ${id} already has mint metadata`);
+                        console.warn(`Smol ${id} already has mint metadata`);
                     }
 
                     // Collect cache tags for list/detail payloads that include mint metadata.

--- a/src/tx-workflow.ts
+++ b/src/tx-workflow.ts
@@ -1,7 +1,7 @@
 import { Keypair, scValToNative, xdr } from "@stellar/stellar-sdk/minimal";
 import { rpc } from "@stellar/stellar-sdk";
 import { basicNodeSigner } from "@stellar/stellar-sdk/minimal/contract";
-import { env, WorkflowEntrypoint, WorkflowEvent, WorkflowStep, WorkflowStepConfig } from "cloudflare:workers";
+import { WorkflowEntrypoint, WorkflowEvent, WorkflowStep, WorkflowStepConfig } from "cloudflare:workers";
 import { Client as SmolClient } from "smol-sdk";
 import { purgeCacheByTags } from "./utils/cache";
 
@@ -12,9 +12,6 @@ type KaleWorkerBinding = Fetcher & {
 		errorCode?: string
 	}>
 }
-
-const KP = Keypair.fromSecret(env.SK)
-const PK = KP.publicKey()
 
 const config: WorkflowStepConfig = {
     retries: {
@@ -105,8 +102,13 @@ export class TxWorkflow extends WorkflowEntrypoint<Env, WorkflowTxParams> {
                     .bind(tokenSACAddress, cometAMMAddress, event.payload.entropy)
                     .run();
 
-                // Purge user's individual smol page
-                await purgeCacheByTags([`user:${event.payload.sub}:smol:${event.payload.entropy}`]);
+                // Purge cached list/detail payloads that include mint metadata.
+                await purgeCacheByTags([
+                    'public-smols',
+                    `user:${event.payload.sub}:created`,
+                    `user:${event.payload.sub}:smol:${event.payload.entropy}`,
+                    `smol:${event.payload.entropy}:anonymous`,
+                ]);
             });
         } else if (event.payload.type === 'batch-mint') {
             await step.do('persist batch mint metadata', config, async () => {
@@ -127,13 +129,17 @@ export class TxWorkflow extends WorkflowEntrypoint<Env, WorkflowTxParams> {
                         .bind(tokenSACAddress, cometAMMAddress, id)
                         .run();
 
-                    // Collect cache tags for user's individual smol pages
+                    // Collect cache tags for list/detail payloads that include mint metadata.
                     smolCacheTags.push(`user:${event.payload.sub}:smol:${id}`);
+                    smolCacheTags.push(`smol:${id}:anonymous`);
                 }
 
-                // Purge user's individual smol pages
                 if (smolCacheTags.length > 0) {
-                    await purgeCacheByTags(smolCacheTags);
+                    await purgeCacheByTags([
+                        'public-smols',
+                        `user:${event.payload.sub}:created`,
+                        ...smolCacheTags,
+                    ]);
                 }
             });
         }
@@ -142,6 +148,8 @@ export class TxWorkflow extends WorkflowEntrypoint<Env, WorkflowTxParams> {
     }
 
     async signTransaction(xdr: string) {
+        const signerKeypair = Keypair.fromSecret(this.env.SK);
+        const signerPublicKey = signerKeypair.publicKey();
         const contract = new SmolClient({
             contractId: this.env.SMOL_CONTRACT_ID,
             rpcUrl: this.env.RPC_URL,
@@ -151,8 +159,8 @@ export class TxWorkflow extends WorkflowEntrypoint<Env, WorkflowTxParams> {
         const at = contract.txFromXDR(xdr);
 
         await at.signAuthEntries({
-            address: PK,
-            signAuthEntry: basicNodeSigner(KP, this.env.NETWORK_PASSPHRASE).signAuthEntry
+            address: signerPublicKey,
+            signAuthEntry: basicNodeSigner(signerKeypair, this.env.NETWORK_PASSPHRASE).signAuthEntry
         });
 
         return at.built!.toXDR();

--- a/src/tx-workflow.ts
+++ b/src/tx-workflow.ts
@@ -107,12 +107,18 @@ export class TxWorkflow extends WorkflowEntrypoint<Env, WorkflowTxParams> {
                     throw new NonRetryableError('Smol already has mint metadata');
                 }
 
+                const ownerSub = event.payload.ownerSub ?? event.payload.sub;
+                const userTags = new Set([
+                    `user:${ownerSub}:created`,
+                    `user:${ownerSub}:smol:${event.payload.entropy}`,
+                    `user:${event.payload.sub}:smol:${event.payload.entropy}`,
+                ]);
+
                 // Purge cached list/detail payloads that include mint metadata.
                 await purgeCacheByTags([
                     'public-smols',
                     'mixtapes',
-                    `user:${event.payload.sub}:created`,
-                    `user:${event.payload.sub}:smol:${event.payload.entropy}`,
+                    ...userTags,
                     `smol:${event.payload.entropy}:anonymous`,
                 ]);
             });
@@ -125,7 +131,7 @@ export class TxWorkflow extends WorkflowEntrypoint<Env, WorkflowTxParams> {
                 }
 
                 // Collect smol IDs for cache purging
-                const smolCacheTags: string[] = [];
+                const smolCacheTags = new Set<string>();
 
                 for (let i = 0; i < results.length; i++) {
                     const [tokenSACAddress, cometAMMAddress] = results[i];
@@ -143,16 +149,19 @@ export class TxWorkflow extends WorkflowEntrypoint<Env, WorkflowTxParams> {
                         console.warn(`Smol ${id} already has mint metadata`);
                     }
 
+                    const ownerSub = event.payload.ownerSubsById?.[id] ?? event.payload.sub;
+
                     // Collect cache tags for list/detail payloads that include mint metadata.
-                    smolCacheTags.push(`user:${event.payload.sub}:smol:${id}`);
-                    smolCacheTags.push(`smol:${id}:anonymous`);
+                    smolCacheTags.add(`user:${ownerSub}:created`);
+                    smolCacheTags.add(`user:${ownerSub}:smol:${id}`);
+                    smolCacheTags.add(`user:${event.payload.sub}:smol:${id}`);
+                    smolCacheTags.add(`smol:${id}:anonymous`);
                 }
 
-                if (smolCacheTags.length > 0) {
+                if (smolCacheTags.size > 0) {
                     await purgeCacheByTags([
                         'public-smols',
                         'mixtapes',
-                        `user:${event.payload.sub}:created`,
                         ...smolCacheTags,
                     ]);
                 }

--- a/src/tx-workflow.ts
+++ b/src/tx-workflow.ts
@@ -148,6 +148,7 @@ export class TxWorkflow extends WorkflowEntrypoint<Env, WorkflowTxParams> {
 
                 for (let i = 0; i < results.length; i++) {
                     const [tokenSACAddress, cometAMMAddress] = results[i];
+                    // The contract returns one result per submitted smol in the same order.
                     const id = resultIds[i];
 
                     const result = await this.env.SMOL_D1.prepare(`

--- a/src/tx-workflow.ts
+++ b/src/tx-workflow.ts
@@ -117,10 +117,9 @@ export class TxWorkflow extends WorkflowEntrypoint<Env, WorkflowTxParams> {
                     `user:${event.payload.sub}:smol:${id}`,
                 ]);
 
-                // Purge cached list/detail payloads that include mint metadata.
+                // Avoid global list purges for common mint writes; short-lived
+                // public/mixtape list caches can refresh naturally.
                 await purgeCacheByTags([
-                    'public-smols',
-                    'mixtapes',
                     ...userTags,
                     `smol:${id}:anonymous`,
                 ]);
@@ -145,8 +144,7 @@ export class TxWorkflow extends WorkflowEntrypoint<Env, WorkflowTxParams> {
                     throw new NonRetryableError('Batch mint result count does not match requested smol count');
                 }
 
-                // Collect smol IDs for cache purging
-                const smolCacheTags = new Set<string>(['public-smols', 'mixtapes']);
+                const smolCacheTags = new Set<string>();
 
                 for (let i = 0; i < results.length; i++) {
                     const [tokenSACAddress, cometAMMAddress] = results[i];

--- a/src/tx-workflow.ts
+++ b/src/tx-workflow.ts
@@ -2,6 +2,7 @@ import { Keypair, scValToNative, xdr } from "@stellar/stellar-sdk/minimal";
 import { rpc } from "@stellar/stellar-sdk";
 import { basicNodeSigner } from "@stellar/stellar-sdk/minimal/contract";
 import { WorkflowEntrypoint, WorkflowEvent, WorkflowStep, WorkflowStepConfig } from "cloudflare:workers";
+import { NonRetryableError } from "cloudflare:workflows";
 import { Client as SmolClient } from "smol-sdk";
 import { purgeCacheByTags } from "./utils/cache";
 
@@ -94,17 +95,22 @@ export class TxWorkflow extends WorkflowEntrypoint<Env, WorkflowTxParams> {
             await step.do('persist mint metadata', config, async () => {
                 const [tokenSACAddress, cometAMMAddress] = scValToNative(xdr.ScVal.fromXDR(res.returnValue, 'base64'));
 
-                await this.env.SMOL_D1.prepare(`
+                const result = await this.env.SMOL_D1.prepare(`
                     UPDATE Smols
                     SET Mint_Token = ?1, Mint_Amm = ?2
-                    WHERE Id = ?3
+                    WHERE Id = ?3 AND Mint_Token IS NULL AND Mint_Amm IS NULL
                 `)
                     .bind(tokenSACAddress, cometAMMAddress, event.payload.entropy)
                     .run();
 
+                if (result.meta.changes === 0) {
+                    throw new NonRetryableError('Smol already has mint metadata');
+                }
+
                 // Purge cached list/detail payloads that include mint metadata.
                 await purgeCacheByTags([
                     'public-smols',
+                    'mixtapes',
                     `user:${event.payload.sub}:created`,
                     `user:${event.payload.sub}:smol:${event.payload.entropy}`,
                     `smol:${event.payload.entropy}:anonymous`,
@@ -121,13 +127,17 @@ export class TxWorkflow extends WorkflowEntrypoint<Env, WorkflowTxParams> {
                     const [tokenSACAddress, cometAMMAddress] = results[i];
                     const id = event.payload.ids![i];
 
-                    await this.env.SMOL_D1.prepare(`
+                    const result = await this.env.SMOL_D1.prepare(`
                         UPDATE Smols
                         SET Mint_Token = ?1, Mint_Amm = ?2
-                        WHERE Id = ?3
+                        WHERE Id = ?3 AND Mint_Token IS NULL AND Mint_Amm IS NULL
                     `)
                         .bind(tokenSACAddress, cometAMMAddress, id)
                         .run();
+
+                    if (result.meta.changes === 0) {
+                        throw new NonRetryableError(`Smol ${id} already has mint metadata`);
+                    }
 
                     // Collect cache tags for list/detail payloads that include mint metadata.
                     smolCacheTags.push(`user:${event.payload.sub}:smol:${id}`);
@@ -137,6 +147,7 @@ export class TxWorkflow extends WorkflowEntrypoint<Env, WorkflowTxParams> {
                 if (smolCacheTags.length > 0) {
                     await purgeCacheByTags([
                         'public-smols',
+                        'mixtapes',
                         `user:${event.payload.sub}:created`,
                         ...smolCacheTags,
                     ]);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,3 @@
-import { Server } from "@stellar/stellar-sdk/minimal/rpc";
-import { env } from "cloudflare:workers";
-
-export const rpc = new Server(env.RPC_URL)
-
 export function sleep(ms: number) {
     return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -28,7 +23,6 @@ export function parseRange(header: string, size: number): { offset: number; leng
 	} else {
 		// If no end is specified, it means from start to the end of the file
 		if (start >= size && size > 0) return undefined; // If size is 0, start=0 is valid for an empty range
-		if (start >= size && size > 0) return undefined; 
 		return { offset: start, length: undefined }; // Explicitly set length to undefined
 	}
 }

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -16,37 +16,48 @@ export async function purgeCacheByTags(tags: string[]): Promise<boolean> {
 		return false
 	}
 
-	if (!tags.length) {
+	const uniqueTags = [...new Set(tags)]
+
+	if (!uniqueTags.length) {
 		console.warn('Cache purge skipped: no tags provided')
 		return false
 	}
 
 	try {
-		const response = await fetch(
-			`https://api.cloudflare.com/client/v4/zones/${env.CF_ZONE_ID}/purge_cache`,
-			{
-				method: 'POST',
-				headers: {
-					'Authorization': `Bearer ${env.CF_API_TOKEN}`,
-					'Content-Type': 'application/json',
-				},
-				body: JSON.stringify({ tags }),
-			}
-		)
-
-		if (!response.ok) {
-			const error = (await response.text()).slice(0, 300)
-			if (response.status === 401 || response.status === 403) {
-				console.warn('Cache purge skipped due auth error:', response.status)
-			} else {
-				console.error('Cache purge failed:', response.status, error)
-			}
-			return false
+		const tagChunks: string[][] = []
+		for (let i = 0; i < uniqueTags.length; i += 30) {
+			tagChunks.push(uniqueTags.slice(i, i + 30))
 		}
 
-		const result = await response.json() as { success: boolean }
-		console.log('Cache purged successfully for tags:', tags)
-		return result.success
+		const results = await Promise.all(tagChunks.map(async (chunk) => {
+			const response = await fetch(
+				`https://api.cloudflare.com/client/v4/zones/${env.CF_ZONE_ID}/purge_cache`,
+				{
+					method: 'POST',
+					headers: {
+						'Authorization': `Bearer ${env.CF_API_TOKEN}`,
+						'Content-Type': 'application/json',
+					},
+					body: JSON.stringify({ tags: chunk }),
+				}
+			)
+
+			if (!response.ok) {
+				const error = (await response.text()).slice(0, 300)
+				if (response.status === 401 || response.status === 403) {
+					console.warn('Cache purge skipped due auth error:', response.status)
+				} else {
+					console.error('Cache purge failed:', response.status, error)
+				}
+				return false
+			}
+
+			const result = await response.json() as { success: boolean }
+			return result.success
+		}))
+
+		console.log('Cache purged for tags:', uniqueTags)
+		return results.every(Boolean)
 	} catch (error) {
 		console.warn('Cache purge error:', error)
 		return false

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -72,7 +72,7 @@ export class Workflow extends WorkflowEntrypoint<Env, WorkflowParams> {
 							}
 						}
 
-						if (!retry_steps) {
+						if (!retry_steps?.payload) {
 							// Fallback for legacy gens and invalid/non-DO IDs
 							retry_steps = await this.env.SMOL_KV.get(retry_id, 'json') as WorkflowSteps;
 						}

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -117,7 +117,7 @@ export class Workflow extends WorkflowEntrypoint<Env, WorkflowParams> {
 				},
 			} as WorkflowStepConfig,
 			async () => {
-				return await pixellab(prompt, 'pixflux');
+				return await pixellab(this.env, prompt, 'pixflux');
 			}
 		);
 

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -79,7 +79,9 @@ export class Workflow extends WorkflowEntrypoint<Env, WorkflowParams> {
 
 						payload = {
 							...payload, // original payload
-							...retry_steps?.payload // previous payload (notably we keep the original address)
+							// Retry can be started by anyone; attribution intentionally stays
+							// with the original smol creator from the saved payload.
+							...retry_steps?.payload
 						};
 					}
 				);

--- a/test/batch-mint.test.ts
+++ b/test/batch-mint.test.ts
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+async function source(path: string) {
+	return readFile(new URL(`../${path}`, import.meta.url), 'utf8')
+}
+
+test('batch mint skips already-minted smols instead of rejecting the whole batch', async () => {
+	const mintSource = await source('src/api/mint.ts')
+
+	assert.match(mintSource, /const mintableIds: string\[\] = \[\]/)
+	assert.match(mintSource, /const alreadyMintedIds: string\[\] = \[\]/)
+	assert.doesNotMatch(mintSource, /throw new HTTPException\(409, \{ message: `Smol \$\{record\.Id\} already minted` \}\)/)
+	assert.match(mintSource, /if \(mintableIds\.length === 0\)/)
+	assert.match(mintSource, /acceptedIds: mintableIds/)
+	assert.match(mintSource, /alreadyMinted: alreadyMintedIds/)
+})
+
+test('batch mint workflow can persist compact results for only mintable ids', async () => {
+	const workflowSource = await source('src/tx-workflow.ts')
+
+	assert.match(workflowSource, /const requestedIds = event\.payload\.ids \?\? \[\]/)
+	assert.match(workflowSource, /const mintableIds = event\.payload\.mintableIds \?\? requestedIds/)
+	assert.match(workflowSource, /results\.length === mintableIds\.length/)
+	assert.match(workflowSource, /const id = resultIds\[i\]/)
+})

--- a/test/media-cache.test.ts
+++ b/test/media-cache.test.ts
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+test('generated R2 media uses long-lived cache headers', async () => {
+	const mediaSource = await readFile(new URL('../src/api/media.ts', import.meta.url), 'utf8')
+
+	assert.match(mediaSource, /MEDIA_CACHE_CONTROL = 'public, max-age=2592000, stale-while-revalidate=86400'/)
+	assert.doesNotMatch(mediaSource, /max-age=300/)
+	assert.match(mediaSource, /headers\.set\('Cache-Control', MEDIA_CACHE_CONTROL\)/)
+	assert.match(mediaSource, /'Cache-Control': MEDIA_CACHE_CONTROL/)
+})

--- a/test/mint-cache-purge.test.ts
+++ b/test/mint-cache-purge.test.ts
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+test('mint completion avoids global cache purges', async () => {
+	const workflowSource = await readFile(new URL('../src/tx-workflow.ts', import.meta.url), 'utf8')
+
+	assert.doesNotMatch(workflowSource, /'public-smols'/)
+	assert.doesNotMatch(workflowSource, /'mixtapes'/)
+	assert.match(workflowSource, /user:\$\{ownerSub\}:smol:\$\{id\}/)
+	assert.match(workflowSource, /smol:\$\{id\}:anonymous/)
+	assert.match(workflowSource, /artistSmolsCacheTag\(ownerSub\)/)
+})

--- a/test/nonpublic-visibility.test.ts
+++ b/test/nonpublic-visibility.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+async function source(path: string) {
+	return readFile(new URL(`../${path}`, import.meta.url), 'utf8')
+}
+
+test('direct smol reads do not treat non-public smols as secret', async () => {
+	const smolsSource = await source('src/api/smols.ts')
+
+	assert.doesNotMatch(smolsSource, /smol_d1\.Public\s*!==\s*1\s*&&\s*smol_d1\.Address/)
+	assert.match(smolsSource, /headers\.set\('Cache-Control', 'public, max-age=30, stale-while-revalidate=60'\)/)
+})
+
+test('authenticated liked-smol list is not filtered to public discovery items', async () => {
+	const smolsSource = await source('src/api/smols.ts')
+
+	assert.doesNotMatch(smolsSource, /l\."Address"\s*=\s*\?\s+AND\s+s\.Public\s*=\s*1/)
+})
+
+test('likes endpoints can include any existing smol, public or non-public', async () => {
+	const likesSource = await source('src/api/likes.ts')
+
+	assert.match(likesSource, /WHERE l\."Address" = \?1/)
+	assert.doesNotMatch(likesSource, /WHERE l\."Address" = \?1 AND s\.Public = 1/)
+	assert.match(likesSource, /SELECT 1 FROM Smols WHERE Id = \?1/)
+	assert.doesNotMatch(likesSource, /SELECT 1 FROM Smols WHERE Id = \?1 AND Public = 1/)
+	assert.doesNotMatch(likesSource, /not public/)
+})

--- a/test/retry-visibility.test.ts
+++ b/test/retry-visibility.test.ts
@@ -20,3 +20,25 @@ test('retry workflow preserves original smol creator attribution', async () => {
 	assert.match(workflowSource, /\.\.\.retry_steps\?\.payload/)
 	assert.match(workflowSource, /const \{ address/)
 })
+
+test('retry smol route accepts DO or KV state instead of requiring a D1 row', async () => {
+	const smolsSource = await source('src/api/smols.ts')
+	const retryRouteSource = smolsSource.slice(
+		smolsSource.indexOf("smols.post('/retry/:id'"),
+		smolsSource.indexOf('// Toggle public/private')
+	)
+
+	assert.match(smolsSource, /async function hasRetryableSmolState/)
+	assert.match(smolsSource, /retrySteps = await stub\.getSteps\(\)/)
+	assert.match(smolsSource, /if \(!retrySteps\?\.payload\) \{/)
+	assert.match(smolsSource, /retrySteps = await env\.SMOL_KV\.get\(id, 'json'\)/)
+	assert.match(smolsSource, /retrySteps\?\.payload\?\.address && retrySteps\?\.payload\?\.prompt/)
+	assert.doesNotMatch(retryRouteSource, /SELECT Id\s+FROM Smols\s+WHERE Id = \?1/)
+})
+
+test('retry workflow falls back to KV if durable object state has flushed', async () => {
+	const workflowSource = await source('src/workflow.ts')
+
+	assert.match(workflowSource, /if \(!retry_steps\?\.payload\) \{/)
+	assert.match(workflowSource, /retry_steps = await this\.env\.SMOL_KV\.get\(retry_id, 'json'\) as WorkflowSteps/)
+})

--- a/test/retry-visibility.test.ts
+++ b/test/retry-visibility.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+async function source(path: string) {
+	return readFile(new URL(`../${path}`, import.meta.url), 'utf8')
+}
+
+test('retry smol route does not require caller authentication', async () => {
+	const smolsSource = await source('src/api/smols.ts')
+
+	assert.match(smolsSource, /smols\.post\('\/retry\/:id', async \(c\) =>/)
+	assert.doesNotMatch(smolsSource, /smols\.post\('\/retry\/:id', parseAuth/)
+})
+
+test('retry workflow preserves original smol creator attribution', async () => {
+	const workflowSource = await source('src/workflow.ts')
+
+	assert.match(workflowSource, /Retry can be started by anyone/)
+	assert.match(workflowSource, /\.\.\.retry_steps\?\.payload/)
+	assert.match(workflowSource, /const \{ address/)
+})

--- a/types/env.d.ts
+++ b/types/env.d.ts
@@ -128,4 +128,6 @@ type WorkflowTxParams = {
 	xdr: string
 	ids?: string[]    // Required for 'batch-mint', not used for 'mint'
 	sub: string       // JWT sub of the user who initiated the mint
+	ownerSub?: string
+	ownerSubsById?: Record<string, string>
 }

--- a/types/env.d.ts
+++ b/types/env.d.ts
@@ -5,6 +5,7 @@ declare namespace Cloudflare {
 	interface Env {
 		SECRET: string
 		SK: string
+		PIXELLAB_KEY: string
 		CF_API_TOKEN: string
 		CF_ZONE_ID: string
 		SEARCH_BACKFILL_CRON_ENABLED: string

--- a/types/env.d.ts
+++ b/types/env.d.ts
@@ -127,6 +127,7 @@ type WorkflowTxParams = {
 	entropy?: string  // Required for 'mint', not used for 'batch-mint'
 	xdr: string
 	ids?: string[]    // Required for 'batch-mint', not used for 'mint'
+	mintableIds?: string[]
 	sub: string       // JWT sub of the user who initiated the mint
 	ownerSub?: string
 	ownerSubsById?: Record<string, string>

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -116,6 +116,7 @@
    * Note: Use secrets to store sensitive data.
    * https://developers.cloudflare.com/workers/configuration/secrets/
    */
+    // Required Worker secrets: SECRET, SK, PIXELLAB_KEY, CF_API_TOKEN, CF_ZONE_ID.
     /**
    * Static Assets
    * https://developers.cloudflare.com/workers/static-assets/binding/

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -21,6 +21,7 @@
     "preview_urls": false,
     "observability": {
         "enabled": true,
+        "head_sampling_rate": 1,
         "logs": {
             "invocation_logs": true
         }


### PR DESCRIPTION
## Summary

This PR applies the small, low-risk fixes from the audit passes over the Worker API. It focuses on public discovery boundaries, endpoint bounds, cache correctness, D1 query support, secret handling, and Cloudflare Worker hardening without changing the core product shape.

Changes include:
- keep generated PNG/MP3 media link-shareable by opaque ID, with 30-day cache headers and per-smol media cache tags
- treat non-public smols as unlisted rather than secret: completed smol detail is readable by ID, and authenticated `/created`, `/liked`, and `/likes` include the caller's non-public items
- keep public discovery surfaces restricted to public/safe items: homepage, artist smol lists, playlists, search, and mixtapes filter to `Public = 1`
- keep in-progress workflow state creator-only and `no-store`, since that state can contain raw generation payloads before a completed smol exists
- allow unauthenticated retry from saved DO or KV workflow state, including failed/in-progress state that never reached D1, while preserving original creator attribution
- fall back to KV retry state when a Durable Object exists but has flushed/empty state
- restrict credentialed CORS to `smol.xyz` origins plus localhost dev origins
- remove the hardcoded Pixellab key from source and require `PIXELLAB_KEY`
- validate prompt, mint, and mixtape payload sizes
- validate mint XDR by parsing `TransactionEnvelope` and enforcing current Mainnet Soroban `tx_max_size_bytes` of 132096 bytes
- keep minting intentionally open to authenticated non-creators; `Smols.Address` is used for attribution/cache invalidation, not mint authorization
- reject invalid, empty, duplicate, or missing batch mint IDs, but skip already-minted smols instead of rejecting the whole batch
- make like insertion idempotent, allow liking any existing completed smol by ID, and allow unliking even after visibility changes
- narrow mint cache purges to the affected artist/user/detail tags instead of globally purging public or mixtape lists on each mint
- keep global public/mixtape purges for visibility changes, deletes, and mixtape creation where public discovery membership can change
- chunk Cloudflare cache-tag purge requests to stay under API limits
- add D1 indexes for hot list/auth/media paths, including `Song_1` and `Song_2`
- guard mint metadata writes against races and make batch-mint metadata retries tolerant
- remove module-scope signer/global RPC setup and enable observability sampling

## Product Semantics Confirmed

Non-public means unlisted from public discovery, not private or secret. Direct completed smol detail and media links remain shareable by ID. User-context lists such as created and liked can include non-public smols because those are authenticated views.

Mixtapes, homepage/public lists, artist public lists, playlists, and search remain public discovery surfaces. They should not include non-public smols.

Minting is intentionally not restricted to the original generated smol creator. Artists/collectors may mint public art they did not create. The code now leaves comments on this because we have run into this mistake multiple times.

## Secret Handling

The existing Pixellab key was removed from source and preserved locally in ignored env files as `PIXELLAB_KEY`. The Worker secret list must include `PIXELLAB_KEY`, along with the other required Worker secrets. The historical Pixellab value should still be rotated because it existed in git history/base branch.

## Migration Notes

The schema changes are additive `CREATE INDEX IF NOT EXISTS` statements only. They should be safe to apply and do not change stored data shape, but production will only benefit once the schema/index SQL is applied to D1.

## Deferred Follow-ups

Larger findings intentionally left for separate work: auth `type:create` contract ownership proof, server-side mint transaction construction or strict contract-call whitelisting, deterministic/idempotent mint workflow IDs, full transaction submission idempotency, streaming large R2 uploads from the Durable Object, exact pagination via `limit + 1`, liked-feed pagination by like time, malformed JSON normalization, exact production CORS origin policy, retry rate limiting, and git history rewrite/secret rotation for the historical Pixellab value.

## Final Adversarial Review

One Codex and one Claude reviewer performed a final Solo adversarial pass. The blocking retry-state regression they found has been fixed in `ee70532`. Remaining concerns are operational or deferred: ensure `PIXELLAB_KEY` is uploaded before deploy, rotate the historical Pixellab key outside this repo, and consider future retry rate limiting.

## Validation

- `npm run typecheck`
- `npm test` (115 passing)
- `git diff --check`
